### PR TITLE
feat: previewコマンドに--limitオプションを追加

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"time"
+	"sort"
 
 	"github.com/canpok1/ai-feed/internal"
 	"github.com/spf13/cobra"
@@ -40,6 +41,18 @@ anything to your local cache.`,
 			}
 			allArticles = append(allArticles, articles...)
 		}
+
+		// Sort all articles by published date in descending order
+		sort.Slice(allArticles, func(i, j int) bool {
+			// Treat articles without a published date as the oldest.
+			if allArticles[i].Published == nil {
+				return false
+			}
+			if allArticles[j].Published == nil {
+				return true
+			}
+			return allArticles[i].Published.After(*allArticles[j].Published)
+		})
 
 		// Apply limit
 		if limit > 0 && len(allArticles) > limit {

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -20,25 +20,40 @@ anything to your local cache.`,
 		if err != nil {
 			return err
 		}
+
+		limit, err := cmd.Flags().GetInt("limit")
+		if err != nil {
+			return err
+		}
+
 		loc, err := time.LoadLocation("Asia/Tokyo")
 		if err != nil {
 			return err
 		}
+
+		var allArticles []*internal.Article
 		for _, url := range urls {
 			articles, err := internal.FetchFeed(url)
 			if err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Error fetching feed from %s: %v\n", url, err)
 				continue
 			}
-			for _, article := range articles {
-				fmt.Printf("Title: %s\n", article.Title)
-				fmt.Printf("Link: %s\n", article.Link)
-                if article.Published != nil {
-                        fmt.Printf("Published: %s\n", article.Published.In(loc).Format("2006-01-02 15:04:05 JST"))
-                }
-                fmt.Printf("Content: %s\n", article.Content)
-                fmt.Println("---")
+			allArticles = append(allArticles, articles...)
+		}
+
+		// Apply limit
+		if limit > 0 && len(allArticles) > limit {
+			allArticles = allArticles[:limit]
+		}
+
+		for _, article := range allArticles {
+			fmt.Printf("Title: %s\n", article.Title)
+			fmt.Printf("Link: %s\n", article.Link)
+			if article.Published != nil {
+				fmt.Printf("Published: %s\n", article.Published.In(loc).Format("2006-01-02 15:04:05 JST"))
 			}
+			fmt.Printf("Content: %s\n", article.Content)
+			fmt.Println("---")
 		}
 		return nil
 	},
@@ -47,4 +62,5 @@ anything to your local cache.`,
 func init() {
 	rootCmd.AddCommand(previewCmd)
 	previewCmd.Flags().StringSliceP("url", "u", []string{}, "URL of the feed to preview")
+	previewCmd.Flags().IntP("limit", "l", 0, "Maximum number of articles to display")
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -31,7 +31,7 @@ anything to your local cache.`,
 			return err
 		}
 
-		var allArticles []*internal.Article
+		var allArticles []internal.Article
 		for _, url := range urls {
 			articles, err := internal.FetchFeed(url)
 			if err != nil {


### PR DESCRIPTION
`preview` コマンドに `--limit` オプションを追加しました。

変更点:
- `--limit <N>` オプションを追加し、表示する記事の最大件数を指定できるようにしました。
- 複数のURLが指定された場合、全てのリソースから取得した記事を合算し、指定された件数で制限します。
- `--limit` オプションが0以下の場合は制限を適用せず、全て表示します。
- ビルドエラーを修正しました。

fixed #6