### PR TITLE
feat: preview コマンドに --source オプションを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,8 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
-    # TODO テスト実装後にコメント解除
-    # - name: Test
-    #   run: make test
+    - name: Test
+      run: make test
 
     - name: Build
       run: make build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ai-feed
 
+AI Feedは、指定されたURLから記事をプレビューしたり、RSSフィードを購読したりするためのCLIツールです。
+
 ## 開発環境
 
 ### 必要条件
@@ -23,3 +25,34 @@ make build
 # clean
 make clean
 ```
+
+## コマンド
+
+### `preview` コマンド
+
+`preview` コマンドは、指定されたURLから記事を一時的に取得し、表示します。購読やキャッシュは行いません。
+
+#### `--url` オプション
+
+プレビューするフィードのURLを指定します。複数のURLを指定できます。
+
+例:
+```bash
+make run option="preview --url https://example.com/feed.xml --url https://another.com/rss"
+```
+
+#### `--source` オプション
+
+URLのリストを含むファイルを指定します。ファイルは1行に1つのURLを記述します。空行はスキップされ、不正なURLは警告が表示されてスキップされます。
+
+例:
+```bash
+# urls.txt の内容:
+# https://example.com/feed.xml
+# https://another.com/rss
+# invalid-url
+
+make run option="preview --source urls.txt"
+```
+
+`--source` オプションと `--url` オプションを同時に使用することはできません。

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -31,7 +31,7 @@ anything to your local cache.`,
 			return err
 		}
 
-		if sourceFile != "" && cmd.Flags().Changed("source") && cmd.Flags().Changed("url") {
+		if cmd.Flags().Changed("source") && cmd.Flags().Changed("url") {
 			return fmt.Errorf("cannot use --source and --url options together")
 		}
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -44,16 +44,7 @@ anything to your local cache.`,
 			urls = append(urls, fileURLs...)
 		}
 
-		// Remove duplicate URLs
-		uniqueURLs := make(map[string]bool)
-		var finalURLs []string
-		for _, url := range urls {
-			if _, ok := uniqueURLs[url]; !ok {
-				uniqueURLs[url] = true
-				finalURLs = append(finalURLs, url)
-			}
-		}
-		urls = finalURLs
+		urls = deduplicateURLs(urls)
 
 		limit, err := cmd.Flags().GetInt("limit")
 		if err != nil {
@@ -142,5 +133,17 @@ func readURLsFromFile(filePath string, cmd *cobra.Command) ([]string, error) {
 	}
 
 	return urls, nil
+}
+
+func deduplicateURLs(urls []string) []string {
+	uniqueURLs := make(map[string]bool)
+	var finalURLs []string
+	for _, url := range urls {
+		if _, ok := uniqueURLs[url]; !ok {
+			uniqueURLs[url] = true
+			finalURLs = append(finalURLs, url)
+		}
+	}
+	return finalURLs
 }
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -44,6 +44,17 @@ anything to your local cache.`,
 			urls = append(urls, fileURLs...)
 		}
 
+		// Remove duplicate URLs
+		uniqueURLs := make(map[string]bool)
+		var finalURLs []string
+		for _, url := range urls {
+			if _, ok := uniqueURLs[url]; !ok {
+				uniqueURLs[url] = true
+				finalURLs = append(finalURLs, url)
+			}
+		}
+		urls = finalURLs
+
 		limit, err := cmd.Flags().GetInt("limit")
 		if err != nil {
 			return err

--- a/cmd/preview_test.go
+++ b/cmd/preview_test.go
@@ -1,0 +1,191 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// createTempFile はテスト用のテンポラリファイルを作成し、そのパスを返します。
+func createTempFile(t *testing.T, content string) string {
+	tmpfile, err := os.CreateTemp("", "test_urls_*.txt")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	if _, err := tmpfile.WriteString(content); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
+	return tmpfile.Name()
+}
+
+// TestReadURLsFromFileValid は有効なURLリストを含むファイルの読み込みをテストします。
+func TestReadURLsFromFileValid(t *testing.T) {
+	content := "http://example.com/1\nhttps://example.org/2\n"
+	filePath := createTempFile(t, content)
+	defer os.Remove(filePath)
+
+	cmd := &cobra.Command{} // モックのcobra.Command
+	urls, err := readURLsFromFile(filePath, cmd)
+	if err != nil {
+		t.Fatalf("readURLsFromFile returned an error: %v", err)
+	}
+
+	expected := []string{"http://example.com/1", "https://example.org/2"}
+	if len(urls) != len(expected) {
+		t.Fatalf("Expected %d URLs, got %d", len(expected), len(urls))
+	}
+	for i, u := range urls {
+		if u != expected[i] {
+			t.Errorf("Expected URL %s, got %s", expected[i], u)
+		}
+	}
+}
+
+// TestReadURLsFromFileEmptyLines は空行を含むファイルの読み込みをテストします。
+func TestReadURLsFromFileEmptyLines(t *testing.T) {
+	content := "http://example.com/1\n\nhttps://example.org/2\n\n"
+	filePath := createTempFile(t, content)
+	defer os.Remove(filePath)
+
+	cmd := &cobra.Command{} // モックのcobra.Command
+	urls, err := readURLsFromFile(filePath, cmd)
+	if err != nil {
+		t.Fatalf("readURLsFromFile returned an error: %v", err)
+	}
+
+	expected := []string{"http://example.com/1", "https://example.org/2"}
+	if len(urls) != len(expected) {
+		t.Fatalf("Expected %d URLs, got %d", len(expected), len(urls))
+	}
+	for i, u := range urls {
+		if u != expected[i] {
+			t.Errorf("Expected URL %s, got %s", expected[i], u)
+		}
+	}
+}
+
+// TestReadURLsFromFileInvalidURLs は不正なURLを含むファイルの読み込みをテストします。
+func TestReadURLsFromFileInvalidURLs(t *testing.T) {
+	content := "http://example.com/1\nnot-a-url\nhttps://example.org/2\n"
+	filePath := createTempFile(t, content)
+	defer os.Remove(filePath)
+
+	// 標準エラー出力をキャプチャ
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	cmd := &cobra.Command{} // モックのcobra.Command
+	urls, err := readURLsFromFile(filePath, cmd)
+
+	w.Close()
+	os.Stderr = oldStderr // 標準エラー出力を元に戻す
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+	stderrOutput := buf.String()
+
+	if err != nil {
+		t.Fatalf("readURLsFromFile returned an error: %v", err)
+	}
+
+	expectedURLs := []string{"http://example.com/1", "https://example.org/2"}
+	if len(urls) != len(expectedURLs) {
+		t.Fatalf("Expected %d URLs, got %d", len(expectedURLs), len(urls))
+	}
+	for i, u := range urls {
+		if u != expectedURLs[i] {
+			t.Errorf("Expected URL %s, got %s", expectedURLs[i], u)
+		}
+	}
+
+	if !strings.Contains(stderrOutput, "Warning: Invalid URL in") || !strings.Contains(stderrOutput, "not-a-url") {
+		t.Errorf("Expected warning for invalid URL, got: %s", stderrOutput)
+	}
+}
+
+// TestReadURLsFromFileNonExistent は存在しないファイルの読み込みをテストします。
+func TestReadURLsFromFileNonExistent(t *testing.T) {
+	cmd := &cobra.Command{} // モックのcobra.Command
+	_, err := readURLsFromFile("non_existent_file.txt", cmd)
+	if err == nil {
+		t.Fatal("readURLsFromFile did not return an error for a non-existent file")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("Expected 'no such file or directory' error, got: %v", err)
+	}
+}
+
+// TestPreviewCommandSourceAndURLConflict は --source と --url オプションの同時使用をテストします。
+func TestPreviewCommandSourceAndURLConflict(t *testing.T) {
+	b := bytes.NewBufferString("")
+	cmd := &cobra.Command{}
+	cmd.SetOut(b)
+	cmd.SetErr(b)
+
+	// フラグを定義
+	cmd.Flags().StringSliceP("url", "u", []string{}, "URL of the feed to preview")
+	cmd.Flags().StringP("source", "s", "", "Path to a file containing a list of URLs to preview")
+	cmd.Flags().IntP("limit", "l", 0, "Maximum number of articles to display")
+
+	// フラグをセット
+	cmd.Flags().Set("url", "http://example.com")
+	cmd.Flags().Set("source", "list.txt")
+
+	err := previewCmd.RunE(cmd, []string{})
+	if err == nil {
+		t.Fatal("Expected an error when --source and --url are used together, but got none.")
+	}
+	if !strings.Contains(err.Error(), "cannot use --source and --url options together") {
+		t.Errorf("Expected conflict error, got: %v", err)
+	}
+}
+
+// TestPreviewCommandDuplicateURLs はURLの重複排除をテストします。
+func TestPreviewCommandDuplicateURLs(t *testing.T) {
+	// テスト用のテンポラリファイルを作成
+	content := "http://example.com/1\nhttp://example.com/2\nhttp://example.com/1\n"
+	filePath := createTempFile(t, content)
+	defer os.Remove(filePath)
+
+	cmd := &cobra.Command{} // モックのcobra.Command
+	cmd.Flags().StringSliceP("url", "u", []string{}, "URL of the feed to preview")
+	cmd.Flags().StringP("source", "s", "", "Path to a file containing a list of URLs to preview")
+	cmd.Flags().IntP("limit", "l", 0, "Maximum number of articles to display")
+
+	// フラグをセット
+	cmd.Flags().Set("source", filePath)
+
+	// readURLsFromFile を直接呼び出してURLリストを取得
+	urls, err := readURLsFromFile(filePath, cmd)
+	if err != nil {
+		t.Fatalf("readURLsFromFile returned an error: %v", err)
+	}
+
+	// 重複排除ロジックを直接テスト
+	uniqueURLs := make(map[string]bool)
+	var finalURLs []string
+	for _, url := range urls {
+		if _, ok := uniqueURLs[url]; !ok {
+			uniqueURLs[url] = true
+			finalURLs = append(finalURLs, url)
+		}
+	}
+
+	expected := []string{"http://example.com/1", "http://example.com/2"}
+	if len(finalURLs) != len(expected) {
+		t.Fatalf("Expected %d unique URLs, got %d", len(expected), len(finalURLs))
+	}
+	for i, u := range finalURLs {
+		if u != expected[i] {
+			t.Errorf("Expected unique URL %s, got %s", expected[i], u)
+		}
+	}
+}
+
+

--- a/cmd/preview_test.go
+++ b/cmd/preview_test.go
@@ -119,21 +119,24 @@ func TestReadURLsFromFile(t *testing.T) {
 
 // TestPreviewCommandSourceAndURLConflict は --source と --url オプションの同時使用をテストします。
 func TestPreviewCommandSourceAndURLConflict(t *testing.T) {
+	// Use the actual previewCmd, which has its flags defined in its init() function.
+	cmd := previewCmd
 	b := bytes.NewBufferString("")
-	cmd := &cobra.Command{}
 	cmd.SetOut(b)
 	cmd.SetErr(b)
 
-	// フラグを定義
-	cmd.Flags().StringSliceP("url", "u", []string{}, "URL of the feed to preview")
-	cmd.Flags().StringP("source", "s", "", "Path to a file containing a list of URLs to preview")
-	cmd.Flags().IntP("limit", "l", 0, "Maximum number of articles to display")
+	// Reset flags to avoid state leakage from other tests.
+	cmd.Flags().Set("url", "")
+	cmd.Flags().Set("source", "")
 
-	// フラグをセット
-	cmd.Flags().Set("url", "http://example.com")
-	cmd.Flags().Set("source", "list.txt")
+	// Simulate user providing flags via arguments.
+	args := []string{"--url", "http://example.com", "--source", "list.txt"}
+	// Manually parse flags to correctly set the "Changed" status.
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
 
-	err := previewCmd.RunE(cmd, []string{})
+	err := cmd.RunE(cmd, args)
 	if err == nil {
 		t.Fatal("Expected an error when --source and --url are used together, but got none.")
 	}


### PR DESCRIPTION
preview コマンドに `--source` オプションを追加し、URL一覧ファイルからのURL読み込み、バリデーション、重複排除、および関連ドキュメントの更新を行いました。

主な変更点:
- `preview` コマンドに `--source` フラグを追加しました。
- URL一覧ファイル (`--source`) からURLを読み込む機能を追加しました。
- URLのバリデーションとエラーハンドリングを実装し、不正なURLは警告を表示してスキップするようにしました。
- `--source` と `--url` オプションの同時使用を禁止するバリデーションを追加しました。
- 読み込んだURLとコマンドライン引数で指定されたURLを統合し、重複を排除するロジックを追加しました。
- 追加した機能の単体テストを作成しました。
- `README.md` に `--source` オプションの使用方法と例を追加しました。

fixed #9