### PR TITLE
feat: instant-recommendコマンドを追加

### DIFF
--- a/cmd/instant_recommend.go
+++ b/cmd/instant_recommend.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"math/rand"
 	"time"
@@ -10,6 +11,11 @@ import (
 
 	"github.com/spf13/cobra"
 )
+
+func displayArticle(w io.Writer, article internal.Article) {
+    fmt.Fprintf(w, "Title: %s\n", article.Title)
+    fmt.Fprintf(w, "Link: %s\n", article.Link)
+}
 
 // instantRecommendCmd represents the instant-recommend command
 var instantRecommendCmd = &cobra.Command{
@@ -21,20 +27,20 @@ recommends one random article from the fetched list.`,
 		url, _ := cmd.Flags().GetString("url")
 		articles, err := internal.FetchFeed(url)
 		if err != nil {
-			log.Fatalf("Failed to fetch feed: %v", err)
+			log.Printf("Failed to fetch feed: %v", err)
+			return
 		}
 
 		if len(articles) == 0 {
-			fmt.Println("No articles found in the feed.")
+			fmt.Fprintln(cmd.OutOrStdout(), "No articles found in the feed.")
 			return
 		}
 
 		rand.Seed(time.Now().UnixNano())
 		randomArticle := articles[rand.Intn(len(articles))]
 
-		fmt.Printf("Title: %s\n", randomArticle.Title)
-		fmt.Printf("Link: %s\n", randomArticle.Link)
-	},
+		displayArticle(cmd.OutOrStdout(), randomArticle)
+    },
 }
 
 func init() {
@@ -43,4 +49,5 @@ func init() {
 	instantRecommendCmd.Flags().StringP("url", "u", "", "URL of the feed to recommend from")
 	instantRecommendCmd.MarkFlagRequired("url")
 }
+
 

--- a/cmd/instant_recommend.go
+++ b/cmd/instant_recommend.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// instantRecommendCmd represents the instant-recommend command
+var instantRecommendCmd = &cobra.Command{
+	Use:   "instant-recommend",
+	Short: "Recommend a random article from a given URL instantly.",
+	Long: `This command fetches articles from the specified URL and
+recommends one random article from the fetched list.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("instant-recommend called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(instantRecommendCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// instantRecommendCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// instantRecommendCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/instant_recommend.go
+++ b/cmd/instant_recommend.go
@@ -2,6 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"log"
+	"math/rand"
+	"time"
+
+	"github.com/canpok1/ai-feed/internal"
 
 	"github.com/spf13/cobra"
 )
@@ -13,20 +18,29 @@ var instantRecommendCmd = &cobra.Command{
 	Long: `This command fetches articles from the specified URL and
 recommends one random article from the fetched list.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("instant-recommend called")
+		url, _ := cmd.Flags().GetString("url")
+		articles, err := internal.FetchFeed(url)
+		if err != nil {
+			log.Fatalf("Failed to fetch feed: %v", err)
+		}
+
+		if len(articles) == 0 {
+			fmt.Println("No articles found in the feed.")
+			return
+		}
+
+		rand.Seed(time.Now().UnixNano())
+		randomArticle := articles[rand.Intn(len(articles))]
+
+		fmt.Printf("Title: %s\n", randomArticle.Title)
+		fmt.Printf("Link: %s\n", randomArticle.Link)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(instantRecommendCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// instantRecommendCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// instantRecommendCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	instantRecommendCmd.Flags().StringP("url", "u", "", "URL of the feed to recommend from")
+	instantRecommendCmd.MarkFlagRequired("url")
 }
+

--- a/cmd/instant_recommend_test.go
+++ b/cmd/instant_recommend_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/canpok1/ai-feed/internal"
+	"github.com/spf13/cobra"
+)
+
+func TestInstantRecommendCommand(t *testing.T) {
+	// Dummy usage to avoid "imported and not used" error for io and cobra
+	_ = io.Writer(nil) // io.Writer is used in displayArticle
+	_ = &cobra.Command{}
+
+	// Save original FetchFeed and restore it after test
+	originalFetchFeed := internal.FetchFeed
+	defer func() {
+		internal.FetchFeed = originalFetchFeed
+	}()
+
+	// Save original log output and restore it after test
+	oldLogOutput := log.Writer()
+	defer func() {
+		log.SetOutput(oldLogOutput)
+	}()
+
+	tests := []struct {
+		name          string
+		url           string
+		mockArticles  []internal.Article
+		expectedOutput []string // Changed to slice for multiple possible outputs
+		expectedErrorOutput string // For stderr
+		expectError   bool
+	}{
+		{
+			name: "Successful recommendation",
+			url:  "http://example.com/feed.xml",
+			mockArticles: []internal.Article{
+				{Title: "Article 1", Link: "http://example.com/article1"},
+				{Title: "Article 2", Link: "http://example.com/article2"},
+			},
+			expectedOutput:      []string{"Title: Article 1\nLink: http://example.com/article1\n", "Title: Article 2\nLink: http://example.com/article2\n"},
+			expectedErrorOutput: "",
+			expectError:         false,
+		},
+		{
+			name:          "No articles found",
+			url:           "http://example.com/empty.xml",
+			mockArticles:  []internal.Article{},
+			expectedOutput:      []string{"No articles found in the feed.\n"},
+			expectedErrorOutput: "",
+			expectError:         false,
+		},
+		{
+			name:          "Fetch feed error",
+			url:           "http://invalid.com/feed.xml",
+			mockArticles:  nil,
+			expectedOutput:      []string{""},
+			expectedErrorOutput: "Failed to fetch feed:", // Partial match for error message
+			expectError:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create buffers to capture stdout and stderr
+			stdoutBuffer := new(bytes.Buffer)
+			stderrBuffer := new(bytes.Buffer)
+
+			// Set command output to buffers
+			instantRecommendCmd.SetOut(stdoutBuffer)
+			instantRecommendCmd.SetErr(stderrBuffer)
+
+			// Redirect log output to stderrBuffer
+			log.SetOutput(stderrBuffer)
+
+			// Reset flags for each test run
+			instantRecommendCmd.Flags().Set("url", tt.url)
+
+			internal.FetchFeed = func(url string) ([]internal.Article, error) {
+				if tt.name == "Fetch feed error" {
+					return nil, fmt.Errorf("mock fetch error")
+				}
+				return tt.mockArticles, nil
+			}
+
+			// Execute the command
+			instantRecommendCmd.Run(instantRecommendCmd, []string{})
+
+			out := stdoutBuffer.String()
+			errOut := stderrBuffer.String()
+
+			if tt.expectError {
+				if !strings.Contains(errOut, tt.expectedErrorOutput) {
+					t.Errorf("Expected stderr to contain '%s', but got '%s'", tt.expectedErrorOutput, errOut)
+				}
+			} else {
+				// Check if stdout contains any of the expected outputs
+				matched := false
+				for _, expected := range tt.expectedOutput {
+					if strings.Contains(out, expected) {
+						matched = true
+						break
+					}
+				}
+				if !matched {
+					t.Errorf("Expected stdout to contain one of %v, but got '%s'", tt.expectedOutput, out)
+				}
+			}
+		})
+	}
+}
+
+func TestDisplayArticle(t *testing.T) {
+	var buf bytes.Buffer
+	article := internal.Article{
+		Title: "Test Article",
+		Link:  "http://test.com/article",
+	}
+	displayArticle(&buf, article)
+
+	expected := "Title: Test Article\nLink: http://test.com/article\n"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+}

--- a/internal/feed.go
+++ b/internal/feed.go
@@ -13,7 +13,11 @@ type Article struct {
 	Content   string
 }
 
-func FetchFeed(url string) ([]Article, error) {
+// FetchFeedFunc defines the signature for the FetchFeed function.
+type FetchFeedFunc func(url string) ([]Article, error)
+
+// DefaultFetchFeed is the default implementation of FetchFeed.
+var DefaultFetchFeed FetchFeedFunc = func(url string) ([]Article, error) {
 	fp := gofeed.NewParser()
 	feed, err := fp.ParseURL(url)
 	if err != nil {
@@ -38,3 +42,6 @@ func FetchFeed(url string) ([]Article, error) {
 	}
 	return articles, nil
 }
+
+// FetchFeed is the function that should be called to fetch feeds. It can be overridden for testing.
+var FetchFeed = DefaultFetchFeed

--- a/internal/feed.go
+++ b/internal/feed.go
@@ -16,8 +16,8 @@ type Article struct {
 // FetchFeedFunc defines the signature for the FetchFeed function.
 type FetchFeedFunc func(url string) ([]Article, error)
 
-// DefaultFetchFeed is the default implementation of FetchFeed.
-var DefaultFetchFeed FetchFeedFunc = func(url string) ([]Article, error) {
+// defaultFetchFeed is the default implementation of FetchFeed.
+var defaultFetchFeed FetchFeedFunc = func(url string) ([]Article, error) {
 	fp := gofeed.NewParser()
 	feed, err := fp.ParseURL(url)
 	if err != nil {
@@ -44,4 +44,4 @@ var DefaultFetchFeed FetchFeedFunc = func(url string) ([]Article, error) {
 }
 
 // FetchFeed is the function that should be called to fetch feeds. It can be overridden for testing.
-var FetchFeed = DefaultFetchFeed
+var FetchFeed = defaultFetchFeed


### PR DESCRIPTION
instant-recommend コマンドを追加しました。
このコマンドは、指定されたURLから記事情報を取得し、その中からランダムに1件の記事を選択して表示します。
`--url` オプションの仕様は `preview` コマンドと同じです。

fixed #13