### PR TITLE
feat: CIに静的解析とフォーマットチェックを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,9 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Lint
+      run: make lint
+
     - name: Test
       run: make test
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Verify Go Formatting
+      run: |
+        make fmt
+        git diff --exit-code
+
     - name: Lint
       run: make lint
 

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,10 @@ clean:
 	rm -f ${BINARY_NAME}
 	rm -rf ./dist
 
-test: vet fmt
+test:
 	go test -v ./...
 
-vet:
+lint:
 	go vet ./...
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,11 @@ clean:
 	rm -f ${BINARY_NAME}
 	rm -rf ./dist
 
-test:
+test: vet fmt
 	go test -v ./...
+
+vet:
+	go vet ./...
+
+fmt:
+	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ make clean
 # test
 make test
 
-# vet (静的解析)
-make vet
+# lint (静的解析)
+make lint
 
 # fmt (コードフォーマット)
 make fmt

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ make build
 
 # clean
 make clean
+
+# test
+make test
+
+# vet (静的解析)
+make vet
+
+# fmt (コードフォーマット)
+make fmt
 ```
 
 ## コマンド

--- a/cmd/instant_recommend_test.go
+++ b/cmd/instant_recommend_test.go
@@ -33,12 +33,12 @@ func TestInstantRecommendCommand(t *testing.T) {
 	}{
 		{
 			name: "Successful recommendation",
-            url:  "http://example.com/feed.xml",
-            mockArticles: []internal.Article{
-                {Title: "Article 1", Link: "http://example.com/article1"},
-                {Title: "Article 2", Link: "http://example.com/com/article2"},
-            },
-            expectedOutput:      []string{"Title: Article 1\nLink: http://example.com/article1\n", "Title: Article 2\nLink: http://example.com/com/article2\n"},
+			url:  "http://example.com/feed.xml",
+			mockArticles: []internal.Article{
+				{Title: "Article 1", Link: "http://example.com/article1"},
+				{Title: "Article 2", Link: "http://example.com/com/article2"},
+			},
+			expectedOutput:      []string{"Title: Article 1\nLink: http://example.com/article1\n", "Title: Article 2\nLink: http://example.com/com/article2\n"},
 			expectedErrorOutput: "",
 			expectError:         false,
 		},
@@ -57,7 +57,7 @@ func TestInstantRecommendCommand(t *testing.T) {
 			expectedOutput:      []string{""},
 			expectedErrorOutput: "Error: failed to fetch feed: mock fetch error\n", // Partial match for error message
 
-			expectError:         true,
+			expectError: true,
 		},
 	}
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -14,8 +14,8 @@ import (
 )
 
 var previewCmd = &cobra.Command{
-	Use:	"preview",
-	Short:	"The preview command temporarily fetches and displays articles from specified URLs or files without subscribing or caching them.",
+	Use:   "preview",
+	Short: "The preview command temporarily fetches and displays articles from specified URLs or files without subscribing or caching them.",
 	Long: `The preview command allows you to quickly view articles
 from specific URLs or a list of URLs in a file. It's perfect for
 checking out content without subscribing to a feed or saving
@@ -146,4 +146,3 @@ func deduplicateURLs(urls []string) []string {
 	}
 	return finalURLs
 }
-

--- a/cmd/preview_test.go
+++ b/cmd/preview_test.go
@@ -26,41 +26,41 @@ func createTempFile(t *testing.T, content string) string {
 
 func TestReadURLsFromFile(t *testing.T) {
 	tests := []struct {
-		name           string
-		content        string
-		expectedURLs   []string
-		expectError    bool
-		expectWarning  bool
-		fileName       string // 存在しないファイルテスト用
+		name          string
+		content       string
+		expectedURLs  []string
+		expectError   bool
+		expectWarning bool
+		fileName      string // 存在しないファイルテスト用
 	}{
 		{
-			name:         "有効なURLリスト",
-			content:      "http://example.com/1\nhttps://example.org/2\n",
-			expectedURLs: []string{"http://example.com/1", "https://example.org/2"},
-			expectError:  false,
+			name:          "有効なURLリスト",
+			content:       "http://example.com/1\nhttps://example.org/2\n",
+			expectedURLs:  []string{"http://example.com/1", "https://example.org/2"},
+			expectError:   false,
 			expectWarning: false,
 		},
 		{
-			name:         "空行を含むURLリスト",
-			content:      "http://example.com/1\n\nhttps://example.org/2\n\n",
-			expectedURLs: []string{"http://example.com/1", "https://example.org/2"},
-			expectError:  false,
+			name:          "空行を含むURLリスト",
+			content:       "http://example.com/1\n\nhttps://example.org/2\n\n",
+			expectedURLs:  []string{"http://example.com/1", "https://example.org/2"},
+			expectError:   false,
 			expectWarning: false,
 		},
 		{
-			name:         "不正なURLを含むURLリスト",
-			content:      "http://example.com/1\nnot-a-url\nhttps://example.org/2\n",
-			expectedURLs: []string{"http://example.com/1", "https://example.org/2"},
-			expectError:  false,
+			name:          "不正なURLを含むURLリスト",
+			content:       "http://example.com/1\nnot-a-url\nhttps://example.org/2\n",
+			expectedURLs:  []string{"http://example.com/1", "https://example.org/2"},
+			expectError:   false,
 			expectWarning: true,
 		},
 		{
-			name:         "存在しないファイル",
-			content:      "",
-			expectedURLs: nil,
-			expectError:  true,
+			name:          "存在しないファイル",
+			content:       "",
+			expectedURLs:  nil,
+			expectError:   true,
 			expectWarning: false,
-			fileName:     "non_existent_file.txt",
+			fileName:      "non_existent_file.txt",
 		},
 	}
 
@@ -148,28 +148,28 @@ func TestPreviewCommandSourceAndURLConflict(t *testing.T) {
 // TestPreviewCommandDuplicateURLs はURLの重複排除をテストします。
 func TestPreviewCommandDuplicateURLs(t *testing.T) {
 	tests := []struct {
-		name     string
-		inputURLs []string
+		name         string
+		inputURLs    []string
 		expectedURLs []string
 	}{
 		{
-			name:     "重複なし",
-			inputURLs: []string{"http://example.com/1", "http://example.com/2"},
+			name:         "重複なし",
+			inputURLs:    []string{"http://example.com/1", "http://example.com/2"},
 			expectedURLs: []string{"http://example.com/1", "http://example.com/2"},
 		},
 		{
-			name:     "重複あり",
-			inputURLs: []string{"http://example.com/1", "http://example.com/2", "http://example.com/1"},
+			name:         "重複あり",
+			inputURLs:    []string{"http://example.com/1", "http://example.com/2", "http://example.com/1"},
 			expectedURLs: []string{"http://example.com/1", "http://example.com/2"},
 		},
 		{
-			name:     "空のリスト",
-			inputURLs: nil,
+			name:         "空のリスト",
+			inputURLs:    nil,
 			expectedURLs: nil,
 		},
 		{
-			name:     "すべて重複",
-			inputURLs: []string{"http://example.com/1", "http://example.com/1", "http://example.com/1"},
+			name:         "すべて重複",
+			inputURLs:    []string{"http://example.com/1", "http://example.com/1", "http://example.com/1"},
 			expectedURLs: []string{"http://example.com/1"},
 		},
 	}


### PR DESCRIPTION
CIに静的解析とフォーマットチェックを追加しました。

主な変更点:
- Makefileにlintターゲットを追加し、go vetを実行するようにしました。
- CI (.github/workflows/build.yml) にlintステップを追加しました。
- CIにGoフォーマット検証ステップを追加し、make fmtを実行後にgit diff --exit-codeで差分がないことを確認するようにしました。
- README.mdにlintとfmtの実行方法を追記しました。

fixed #16