### PR TITLE
feat: internal/domain/file.go を internal/infra/file.go に移動

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -33,7 +33,7 @@ anything to your local cache.`,
 
 			if sourceFile != "" {
 				// Read URLs from file
-				fileURLs, err := domain.ReadURLsFromFile(sourceFile, func(filePath, line string, err error) error {
+				fileURLs, err := infra.ReadURLsFromFile(sourceFile, func(filePath, line string, err error) error {
 					fmt.Fprintf(cmd.ErrOrStderr(), "Warning: Skipping invalid URL in %s on line '%s': %v\n", filePath, line, err)
 					return nil
 				})

--- a/internal/infra/file.go
+++ b/internal/infra/file.go
@@ -1,4 +1,4 @@
-package domain
+package infra
 
 import (
 	"bufio"


### PR DESCRIPTION
ReadURLsFromFile 関数を internal/domain から internal/infra に移動しました。これにより、ファイル読み込み関連のロジックが infra パッケージに集約され、コードの責務がより明確になりました。

- internal/domain/file.go を internal/infra/file.go に移動。
- パッケージ名を domain から infra に変更。
- cmd/preview.go での ReadURLsFromFile の呼び出しを domain.ReadURLsFromFile から infra.ReadURLsFromFile に修正。
- make fmt, make test, make build が正常に実行されることを確認済み。