### PR TITLE
feat: Misskey連携機能の追加とViewerインターフェースの改善

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -115,10 +115,11 @@ func newRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 			viewers = append(viewers, slackViewer)
 		}
 		if outputConfig.Misskey != nil {
-			// TODO: MisskeyViewer の実装と初期化
-			// misskeyViewer := infra.NewMisskeyViewer(outputConfig.MisskeyConfig);
-			// viewers = append(viewers, misskeyViewer);
-			fmt.Fprintf(stderr, "Warning: misskey output type is not yet supported, skipping\n")
+			misskeyViewer, err := infra.NewMisskeyViewer(outputConfig.Misskey.APIURL, outputConfig.Misskey.APIToken)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create Misskey viewer: %w", err)
+			}
+			viewers = append(viewers, misskeyViewer)
 		}
 	}
 

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/canpok1/ai-feed/internal"
 	"github.com/canpok1/ai-feed/internal/domain"
-	"github.com/canpok1/ai-feed/internal/domain/entity"
 	"github.com/canpok1/ai-feed/internal/infra"
 
 	"github.com/spf13/cobra"
@@ -107,11 +106,7 @@ func newRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 
 	if outputConfig != nil {
 		if outputConfig.SlackAPI != nil {
-			var promptConfigEntity *entity.PromptConfig
-			if promptConfig != nil {
-				promptConfigEntity = promptConfig.ToEntity()
-			}
-			slackViewer := infra.NewSlackViewer(outputConfig.SlackAPI.ToEntity(), promptConfigEntity)
+			slackViewer := infra.NewSlackViewer(outputConfig.SlackAPI.ToEntity())
 			viewers = append(viewers, slackViewer)
 		}
 		if outputConfig.Misskey != nil {
@@ -159,7 +154,7 @@ func (r *recommendRunner) Run(cmd *cobra.Command, p *recommendParams, profile in
 
 	var errs []error
 	for _, viewer := range r.viewers {
-		err = viewer.ViewRecommend(recommend)
+		err = viewer.ViewRecommend(recommend, profile.Prompt.FixedMessage)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to view recommend: %w", err))
 		}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 require (
 	github.com/go-test/deep v1.1.1
 	github.com/slack-go/slack v0.17.3
+	github.com/yitsushi/go-misskey v1.1.6
 	google.golang.org/genai v1.17.0
 )
 
@@ -37,6 +38,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
 github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
@@ -68,8 +70,11 @@ github.com/spf13/pflag v1.0.7 h1:vN6T9TfwStFPFM5XzjsvmzZkLuaLX+HS+0SeFLRgU6M=
 github.com/spf13/pflag v1.0.7/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/yitsushi/go-misskey v1.1.6 h1:aMfu7N9RzS2JO2QP9TPBXQyvudwU7NTr6jiOeUcho3Q=
+github.com/yitsushi/go-misskey v1.1.6/go.mod h1:FeLNMTVebkWTbjRt5X1YqkKc61dOjgTy2hyUDaOC+zc=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
@@ -124,6 +129,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -171,5 +177,6 @@ google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/domain/view.go
+++ b/internal/domain/view.go
@@ -10,7 +10,7 @@ import (
 
 type Viewer interface {
 	ViewArticles([]entity.Article) error
-	ViewRecommend(*entity.Recommend) error
+	ViewRecommend(*entity.Recommend, string) error
 }
 
 type StdViewer struct {
@@ -47,7 +47,7 @@ func (v *StdViewer) ViewArticles(articles []entity.Article) error {
 	return nil
 }
 
-func (v *StdViewer) ViewRecommend(recommend *entity.Recommend) error {
+func (v *StdViewer) ViewRecommend(recommend *entity.Recommend, fixedMessage string) error {
 	if recommend == nil {
 		fmt.Fprintln(v.writer, "No articles found in the feed.")
 		return nil
@@ -57,6 +57,10 @@ func (v *StdViewer) ViewRecommend(recommend *entity.Recommend) error {
 	fmt.Fprintf(v.writer, "Link: %s\n", recommend.Article.Link)
 	if recommend.Comment != nil {
 		fmt.Fprintf(v.writer, "Comment: %s\n", *recommend.Comment)
+	}
+	// fixedMessage を追加
+	if fixedMessage != "" {
+		fmt.Fprintf(v.writer, "Fixed Message: %s\n", fixedMessage)
 	}
 	return nil
 }

--- a/internal/infra/misskey_viewer.go
+++ b/internal/infra/misskey_viewer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/canpok1/ai-feed/internal/domain"
 	"github.com/canpok1/ai-feed/internal/domain/entity"
@@ -47,14 +48,17 @@ func (v *MisskeyViewer) ViewRecommend(recommend *entity.Recommend, fixedMessage 
 		return fmt.Errorf("recommend is nil")
 	}
 
-	text := fmt.Sprintf("Title: %s\nLink: %s", recommend.Article.Title, recommend.Article.Link)
+	var b strings.Builder
+	fmt.Fprintf(&b, "Title: %s\nLink: %s", recommend.Article.Title, recommend.Article.Link)
 	if recommend.Comment != nil {
-		text = fmt.Sprintf("%s\nComment: %s", text, *recommend.Comment)
+		fmt.Fprintf(&b, "\nComment: %s", *recommend.Comment)
 	}
 	// fixedMessage を追加
 	if fixedMessage != "" {
-		text = fmt.Sprintf("%s\nFixed Message: %s", text, fixedMessage)
+		fmt.Fprintf(&b, "\nFixed Message: %s", fixedMessage)
 	}
+
+	text := b.String()
 
 	params := notes.CreateRequest{
 		Text:       &text,

--- a/internal/infra/misskey_viewer.go
+++ b/internal/infra/misskey_viewer.go
@@ -1,0 +1,66 @@
+package infra
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/canpok1/ai-feed/internal/domain"
+	"github.com/canpok1/ai-feed/internal/domain/entity"
+	"github.com/yitsushi/go-misskey"
+	"github.com/yitsushi/go-misskey/models"
+	"github.com/yitsushi/go-misskey/services/notes"
+)
+
+// MisskeyViewer はMisskey APIと通信するためのクライアントです。
+type MisskeyViewer struct {
+	client *misskey.Client
+}
+
+// NewMisskeyViewer は新しいMisskeyViewerのインスタンスを作成します。
+func NewMisskeyViewer(instanceURL, accessToken string) (domain.Viewer, error) {
+	parsedURL, err := url.Parse(instanceURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse instance URL: %w", err)
+	}
+
+	client, err := misskey.NewClientWithOptions(
+		misskey.WithBaseURL(parsedURL.Scheme, parsedURL.Host, parsedURL.Path),
+		misskey.WithAPIToken(accessToken),
+		misskey.WithHTTPClient(&http.Client{}),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Misskey client: %w", err)
+	}
+
+	return &MisskeyViewer{client: client}, nil
+}
+
+// ViewArticles はMisskeyViewerでは未実装です。
+func (v *MisskeyViewer) ViewArticles(articles []entity.Article) error {
+	return nil
+}
+
+// ViewRecommend はMisskeyにノートを投稿します。
+func (v *MisskeyViewer) ViewRecommend(recommend *entity.Recommend) error {
+	if recommend == nil {
+		return fmt.Errorf("recommend is nil")
+	}
+
+	text := fmt.Sprintf("Title: %s\nLink: %s", recommend.Article.Title, recommend.Article.Link)
+	if recommend.Comment != nil {
+		text = fmt.Sprintf("%s\nComment: %s", text, *recommend.Comment)
+	}
+
+	params := notes.CreateRequest{
+		Text:       &text,
+		Visibility: models.VisibilityPublic,
+	}
+
+	_, err := v.client.Notes().Create(params)
+	if err != nil {
+		return fmt.Errorf("failed to create note: %w", err)
+	}
+
+	return nil
+}

--- a/internal/infra/misskey_viewer.go
+++ b/internal/infra/misskey_viewer.go
@@ -42,7 +42,7 @@ func (v *MisskeyViewer) ViewArticles(articles []entity.Article) error {
 }
 
 // ViewRecommend はMisskeyにノートを投稿します。
-func (v *MisskeyViewer) ViewRecommend(recommend *entity.Recommend) error {
+func (v *MisskeyViewer) ViewRecommend(recommend *entity.Recommend, fixedMessage string) error {
 	if recommend == nil {
 		return fmt.Errorf("recommend is nil")
 	}
@@ -50,6 +50,10 @@ func (v *MisskeyViewer) ViewRecommend(recommend *entity.Recommend) error {
 	text := fmt.Sprintf("Title: %s\nLink: %s", recommend.Article.Title, recommend.Article.Link)
 	if recommend.Comment != nil {
 		text = fmt.Sprintf("%s\nComment: %s", text, *recommend.Comment)
+	}
+	// fixedMessage を追加
+	if fixedMessage != "" {
+		text = fmt.Sprintf("%s\nFixed Message: %s", text, fixedMessage)
 	}
 
 	params := notes.CreateRequest{

--- a/internal/infra/slack.go
+++ b/internal/infra/slack.go
@@ -9,16 +9,14 @@ import (
 )
 
 type SlackViewer struct {
-	client       *slack.Client
-	channelID    string
-	promptConfig *entity.PromptConfig
+	client    *slack.Client
+	channelID string
 }
 
-func NewSlackViewer(config *entity.SlackAPIConfig, promptConfig *entity.PromptConfig) domain.Viewer {
+func NewSlackViewer(config *entity.SlackAPIConfig) domain.Viewer {
 	return &SlackViewer{
-		client:       slack.New(config.APIToken),
-		channelID:    config.Channel,
-		promptConfig: promptConfig,
+		client:    slack.New(config.APIToken),
+		channelID: config.Channel,
 	}
 }
 
@@ -27,7 +25,7 @@ func (s *SlackViewer) ViewArticles(articles []entity.Article) error {
 	return nil
 }
 
-func (v *SlackViewer) ViewRecommend(recommend *entity.Recommend) error {
+func (v *SlackViewer) ViewRecommend(recommend *entity.Recommend, fixedMessage string) error {
 	var messages []string
 	if recommend.Comment != nil && *recommend.Comment != "" {
 		messages = make([]string, 0, 3)
@@ -39,8 +37,10 @@ func (v *SlackViewer) ViewRecommend(recommend *entity.Recommend) error {
 	messages = append(messages, recommend.Article.Link)
 
 	msg := strings.Join(messages, "\n")
-	if v.promptConfig != nil && v.promptConfig.FixedMessage != "" {
-		msg = msg + "\n" + v.promptConfig.FixedMessage
+
+	// 引数で渡されたfixedMessageを使用
+	if fixedMessage != "" {
+		msg = msg + "\n" + fixedMessage
 	}
 
 	return v.postMessage(msg)


### PR DESCRIPTION
GitHub Issue #48 の対応として、Misskey連携機能を追加し、Viewerインターフェースを改善しました。

主な変更点:
- Misskey APIと連携するための `MisskeyViewer` を実装し、`domain.Viewer` インターフェースに適合させました。
- `NewMisskeyViewer` 関数の戻り値の型を `domain.Viewer` に変更しました。
- `Viewer` インターフェースの `ViewRecommend` メソッドに `fixedMessage` 引数を追加しました。
- `SlackViewer` から `promptConfig` フィールドを削除し、`fixedMessage` を引数で受け取るように変更しました。
- ソースコード内のエラー文言を英語に統一しました。

fixed #48