### PR TITLE
日本語コメント付きconfig/profile YAML生成機能を実装

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -30,8 +30,8 @@ func makeConfigInitCmd() *cobra.Command {
 
 			configRepo := infra.NewYamlConfigRepository(filePath)
 
-			config := infra.MakeDefaultConfig()
-			if err := configRepo.Save(config); err != nil {
+			// テンプレートを使用してコメント付きconfig.ymlを生成
+			if err := configRepo.SaveWithTemplate(); err != nil {
 				return err
 			}
 			fmt.Printf("%s generated\n", filePath)

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -39,9 +39,9 @@ func makeProfileInitCmd() *cobra.Command {
 				return
 			}
 
-			profile := infra.NewDefaultProfile()
 			profileRepo := infra.NewYamlProfileRepository(filePath)
-			err := profileRepo.SaveProfile(profile)
+			// テンプレートを使用してコメント付きprofile.ymlを生成
+			err := profileRepo.SaveProfileWithTemplate()
 			if err != nil {
 				cmd.PrintErrf("Failed to create profile file: %v\n", err)
 				return

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -3,46 +3,29 @@ package infra
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/template"
 
 	"github.com/canpok1/ai-feed/internal/domain/entity"
 	"gopkg.in/yaml.v3"
 )
 
+// indentLines は文字列の各行に指定されたインデントを追加する
+func indentLines(text, indent string) string {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = indent + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 // configYmlTemplate は、config initコマンドで生成するconfig.ymlのテンプレート文字列
-const configYmlTemplate = `# AI Feedの設定ファイル
+var configYmlTemplate = `# AI Feedの設定ファイル
 # このファイルには全プロファイル共通のデフォルト設定を定義します
 default_profile:
-  # AI設定
-  ai:
-    gemini:
-      type: gemini-2.5-flash      # 使用するGeminiモデル
-      api_key: xxxxxx             # Google AI Studio APIキー
-  
-  # プロンプト設定
-  system_prompt: あなたはXXXXなAIアシスタントです。  # AIに与えるシステムプロンプト
-  comment_prompt_template: |                          # 記事紹介文生成用のプロンプトテンプレート
-    以下の記事の紹介文を100字以内で作成してください。
-    ---
-    記事タイトル: {{"{{title}}"}}
-    記事URL: {{"{{url}}"}}
-    記事内容:
-    {{"{{content}}"}}
-  fixed_message: 固定の文言です。                      # 記事紹介文に追加する固定文言
-  
-  # 出力先設定
-  output:
-    # Slack投稿設定
-    slack_api:
-      api_token: xxxxxx           # Slack Bot Token
-      api_url: https://example.com # Slack API URL
-      channel: "#general"         # 投稿先チャンネル
-    
-    # Misskey投稿設定
-    misskey:
-      api_token: xxxxxx           # Misskeyアクセストークン
-      api_url: https://misskey.social/api            # MisskeyのAPIエンドポイント
-`
+` + indentLines(commonProfileTemplate, "  ")
 
 type Config struct {
 	DefaultProfile *Profile `yaml:"default_profile,omitempty"`

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -16,7 +16,7 @@ default_profile:
   # AI設定
   ai:
     gemini:
-      type: gemini-1.5-flash      # 使用するGeminiモデル
+      type: gemini-2.5-flash      # 使用するGeminiモデル
       api_key: xxxxxx             # Google AI Studio APIキー
   
   # プロンプト設定

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -34,12 +34,12 @@ default_profile:
   output:
     # Slack投稿設定
     slack_api:
-      api_token: xoxb-xxxxxx      # Slack Bot Token
+      api_token: xxxxxx           # Slack Bot Token
       channel: "#general"         # 投稿先チャンネル
     
     # Misskey投稿設定
     misskey:
-      api_token: YOUR_MISSKEY_PUBLIC_API_TOKEN_HERE  # Misskeyアクセストークン
+      api_token: xxxxxx           # Misskeyアクセストークン
       api_url: https://misskey.social/api            # MisskeyのAPIエンドポイント
 `
 

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -8,6 +8,40 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// configYmlTemplate は、config initコマンドで生成するconfig.ymlのテンプレート文字列
+const configYmlTemplate = `# AI Feedの設定ファイル
+# このファイルには全プロファイル共通のデフォルト設定を定義します
+default_profile:
+  # AI設定
+  ai:
+    gemini:
+      type: gemini-1.5-flash      # 使用するGeminiモデル
+      api_key: xxxxxx             # Google AI Studio APIキー
+  
+  # プロンプト設定
+  system_prompt: あなたはXXXXなAIアシスタントです。  # AIに与えるシステムプロンプト
+  comment_prompt_template: |                          # 記事紹介文生成用のプロンプトテンプレート
+    以下の記事の紹介文を100字以内で作成してください。
+    ---
+    記事タイトル: {{title}}
+    記事URL: {{url}}
+    記事内容:
+    {{content}}
+  fixed_message: 固定の文言です。                      # 記事紹介文に追加する固定文言
+  
+  # 出力先設定
+  output:
+    # Slack投稿設定
+    slack_api:
+      api_token: xoxb-xxxxxx      # Slack Bot Token
+      channel: "#general"         # 投稿先チャンネル
+    
+    # Misskey投稿設定
+    misskey:
+      api_token: YOUR_MISSKEY_PUBLIC_API_TOKEN_HERE  # Misskeyアクセストークン
+      api_url: https://misskey.social/api            # MisskeyのAPIエンドポイント
+`
+
 type Config struct {
 	DefaultProfile *Profile `yaml:"default_profile,omitempty"`
 }

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -35,6 +35,7 @@ default_profile:
     # Slack投稿設定
     slack_api:
       api_token: xxxxxx           # Slack Bot Token
+      api_url: https://example.com # Slack API URL
       channel: "#general"         # 投稿先チャンネル
     
     # Misskey投稿設定

--- a/internal/infra/profile.go
+++ b/internal/infra/profile.go
@@ -9,10 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// profileYmlTemplate は、profile initコマンドで生成するprofile.ymlのテンプレート文字列
-const profileYmlTemplate = `# AI Feedのプロファイル設定ファイル
-# このファイルの設定は config.yml のデフォルトプロファイル設定を上書きします
-# AI設定
+// commonProfileTemplate は、プロファイル設定の共通部分のテンプレート文字列
+const commonProfileTemplate = `# AI設定
 ai:
   gemini:
     type: gemini-2.5-flash                  # 使用するGeminiモデル
@@ -40,8 +38,12 @@ output:
   # Misskey投稿設定
   misskey:
     api_token: xxxxxx                       # Misskeyアクセストークン
-    api_url: https://misskey.social/api     # MisskeyのAPIエンドポイント
-`
+    api_url: https://misskey.social/api     # MisskeyのAPIエンドポイント`
+
+// profileYmlTemplate は、profile initコマンドで生成するprofile.ymlのテンプレート文字列
+var profileYmlTemplate = `# AI Feedのプロファイル設定ファイル
+# このファイルの設定は config.yml のデフォルトプロファイル設定を上書きします
+` + commonProfileTemplate
 
 type YamlProfileRepository struct {
 	filePath string

--- a/internal/infra/profile.go
+++ b/internal/infra/profile.go
@@ -8,6 +8,39 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// profileYmlTemplate は、profile initコマンドで生成するprofile.ymlのテンプレート文字列
+const profileYmlTemplate = `# AI Feedのプロファイル設定ファイル
+# このファイルの設定は config.yml のデフォルトプロファイル設定を上書きします
+# AI設定
+ai:
+  gemini:
+    type: gemini-1.5-flash                  # 使用するGeminiモデル
+    api_key: YOUR_GEMINI_API_KEY_HERE       # Google AI Studio APIキー
+
+# プロンプト設定
+system_prompt: あなたはXXXXなAIアシスタントです。    # AIに与えるシステムプロンプト
+comment_prompt_template: |                         # 記事紹介文生成用のプロンプトテンプレート
+  以下の記事の紹介文を100字以内で作成してください。
+  ---
+  記事タイトル: {{title}}
+  記事URL: {{url}}
+  記事内容:
+  {{content}}
+fixed_message: 固定の文言です。                     # 記事紹介文に追加する固定文言
+
+# 出力先設定
+output:
+  # Slack投稿設定
+  slack_api:
+    api_token: xoxb-YOUR_SLACK_API_TOKEN_HERE   # Slack Bot Token
+    channel: "#general"                         # 投稿先チャンネル
+  
+  # Misskey投稿設定
+  misskey:
+    api_token: YOUR_MISSKEY_PUBLIC_API_TOKEN_HERE  # Misskeyアクセストークン
+    api_url: https://misskey.social/api            # MisskeyのAPIエンドポイント
+`
+
 type YamlProfileRepository struct {
 	filePath string
 }

--- a/internal/infra/profile.go
+++ b/internal/infra/profile.go
@@ -15,7 +15,7 @@ const profileYmlTemplate = `# AI Feedのプロファイル設定ファイル
 # AI設定
 ai:
   gemini:
-    type: gemini-1.5-flash                  # 使用するGeminiモデル
+    type: gemini-2.5-flash                  # 使用するGeminiモデル
     api_key: xxxxxx                         # Google AI Studio APIキー
 
 # プロンプト設定

--- a/internal/infra/profile.go
+++ b/internal/infra/profile.go
@@ -16,7 +16,7 @@ const profileYmlTemplate = `# AI Feedのプロファイル設定ファイル
 ai:
   gemini:
     type: gemini-1.5-flash                  # 使用するGeminiモデル
-    api_key: YOUR_GEMINI_API_KEY_HERE       # Google AI Studio APIキー
+    api_key: xxxxxx                         # Google AI Studio APIキー
 
 # プロンプト設定
 system_prompt: あなたはXXXXなAIアシスタントです。    # AIに与えるシステムプロンプト
@@ -33,13 +33,13 @@ fixed_message: 固定の文言です。                     # 記事紹介文に
 output:
   # Slack投稿設定
   slack_api:
-    api_token: xoxb-YOUR_SLACK_API_TOKEN_HERE   # Slack Bot Token
-    channel: "#general"                         # 投稿先チャンネル
+    api_token: xxxxxx                       # Slack Bot Token
+    channel: "#general"                     # 投稿先チャンネル
   
   # Misskey投稿設定
   misskey:
-    api_token: YOUR_MISSKEY_PUBLIC_API_TOKEN_HERE  # Misskeyアクセストークン
-    api_url: https://misskey.social/api            # MisskeyのAPIエンドポイント
+    api_token: xxxxxx                       # Misskeyアクセストークン
+    api_url: https://misskey.social/api     # MisskeyのAPIエンドポイント
 `
 
 type YamlProfileRepository struct {

--- a/internal/infra/profile.go
+++ b/internal/infra/profile.go
@@ -34,6 +34,7 @@ output:
   # Slack投稿設定
   slack_api:
     api_token: xxxxxx                       # Slack Bot Token
+    api_url: https://example.com            # Slack API URL
     channel: "#general"                     # 投稿先チャンネル
   
   # Misskey投稿設定


### PR DESCRIPTION
## Summary
- config initとprofile initコマンドで日本語コメント付きYAMLファイルを生成する機能を実装
- 各設定項目に分かりやすい日本語コメントを追加して、ユーザーがより理解しやすい設定ファイルを提供
- テンプレートベースの実装により、コメントを含む構造化された設定ファイルを生成

## 主な変更点
- `internal/infra/config.go`: configYmlTemplateの定義とSaveWithTemplate()メソッドの追加
- `internal/infra/profile.go`: profileYmlTemplateの定義とSaveProfileWithTemplate()メソッドの追加  
- `cmd/config.go`: config initコマンドでテンプレートベース生成を使用
- `cmd/profile.go`: profile initコマンドでテンプレートベース生成を使用

## 機能詳細
- **日本語コメント**: 各設定項目に分かりやすい日本語説明を追加
- **統一されたプレースホルダー**: 全てのAPIキー・トークンをxxxxxxに統一
- **最新モデル対応**: Gemini 2.5 Flashモデルをデフォルトに設定
- **Slack API URL**: 新たにapi_urlフィールドを追加
- **後方互換性**: 既存のSave()メソッドを保持し、テストが通ることを確認

## Test plan
- [x] 全テストの実行 (`make test`)
- [x] 静的解析の実行 (`make lint`) 
- [x] config initコマンドでコメント付きconfig.yml生成を確認
- [x] profile initコマンドでコメント付きprofile.yml生成を確認
- [x] 生成されたYAMLファイルが既存ローダーで正常読み込み可能を確認
- [x] 既存ファイル上書き保護機能の動作確認

fixed #80

🤖 Generated with [Claude Code](https://claude.ai/code)