### PR TITLE
インターフェースのリファクタリング

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -7,12 +7,13 @@ import (
 	"github.com/canpok1/ai-feed/cmd/runner"
 	"github.com/canpok1/ai-feed/internal/domain"
 	"github.com/canpok1/ai-feed/internal/infra"
+	"github.com/canpok1/ai-feed/internal/infra/comment"
 	"github.com/canpok1/ai-feed/internal/infra/profile"
 
 	"github.com/spf13/cobra"
 )
 
-func makeRecommendCmd(fetchClient domain.FetchClient, recommender domain.Recommender) *cobra.Command {
+func makeRecommendCmd(fetchClient domain.FetchClient) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "recommend",
 		Short: "Recommend a random article from a given URL instantly.",
@@ -45,6 +46,24 @@ recommends one random article from the fetched list.`,
 				}
 				currentProfile.Merge(loadedInfraProfile)
 			}
+
+			// AIConfig と PromptConfig を取得
+			var aiConfig *infra.AIConfig
+			var promptConfig *infra.PromptConfig
+
+			if currentProfile.AI != nil {
+				aiConfig = currentProfile.AI
+			}
+			if currentProfile.Prompt != nil {
+				promptConfig = currentProfile.Prompt
+			}
+
+			// Recommender を作成
+			recommender := domain.NewRandomRecommender(
+				comment.NewCommentGeneratorFactory(),
+				aiConfig.ToEntity(),
+				promptConfig.ToEntity(),
+			)
 
 			recommendRunner, runnerErr := runner.NewRecommendRunner(fetchClient, recommender, cmd.OutOrStdout(), cmd.ErrOrStderr(), currentProfile.Output, currentProfile.Prompt)
 			if runnerErr != nil {

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/canpok1/ai-feed/cmd/runner"
 	"github.com/canpok1/ai-feed/internal/domain"
+	"github.com/canpok1/ai-feed/internal/domain/entity"
 	"github.com/canpok1/ai-feed/internal/infra"
 	"github.com/canpok1/ai-feed/internal/infra/comment"
 	"github.com/canpok1/ai-feed/internal/infra/profile"
@@ -48,21 +49,21 @@ recommends one random article from the fetched list.`,
 			}
 
 			// AIConfig と PromptConfig を取得
-			var aiConfig *infra.AIConfig
-			var promptConfig *infra.PromptConfig
-
+			var aiConfigEntity *entity.AIConfig
 			if currentProfile.AI != nil {
-				aiConfig = currentProfile.AI
+				aiConfigEntity = currentProfile.AI.ToEntity()
 			}
+
+			var promptConfigEntity *entity.PromptConfig
 			if currentProfile.Prompt != nil {
-				promptConfig = currentProfile.Prompt
+				promptConfigEntity = currentProfile.Prompt.ToEntity()
 			}
 
 			// Recommender を作成
 			recommender := domain.NewRandomRecommender(
 				comment.NewCommentGeneratorFactory(),
-				aiConfig.ToEntity(),
-				promptConfig.ToEntity(),
+				aiConfigEntity,
+				promptConfigEntity,
 			)
 
 			recommendRunner, runnerErr := runner.NewRecommendRunner(fetchClient, recommender, cmd.OutOrStdout(), cmd.ErrOrStderr(), currentProfile.Output, currentProfile.Prompt)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"github.com/canpok1/ai-feed/internal/domain"
-	"github.com/canpok1/ai-feed/internal/infra/comment"
 	"github.com/canpok1/ai-feed/internal/infra/fetch"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +19,7 @@ func makeRootCmd() *cobra.Command {
 func Execute() error {
 	rootCmd := makeRootCmd()
 
-	recommendCmd := makeRecommendCmd(fetch.NewFetchClient(), domain.NewRandomRecommender(comment.NewCommentGeneratorFactory()))
+	recommendCmd := makeRecommendCmd(fetch.NewFetchClient())
 	rootCmd.AddCommand(recommendCmd)
 
 	configCmd := makeConfigCmd()

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -79,8 +79,13 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 	}
 
 	var errs []error
+	fixedMessage := ""
+	if profile.Prompt != nil {
+		fixedMessage = profile.Prompt.FixedMessage
+	}
+
 	for _, viewer := range r.viewers {
-		if viewErr := viewer.SendRecommend(recommend, profile.Prompt.FixedMessage); viewErr != nil {
+		if viewErr := viewer.SendRecommend(recommend, fixedMessage); viewErr != nil {
 			errs = append(errs, fmt.Errorf("failed to view recommend: %w", viewErr))
 		}
 	}

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -73,18 +73,7 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 		return ErrNoArticlesFound
 	}
 
-	if profile.AI == nil || profile.Prompt == nil {
-		return fmt.Errorf("AI model or prompt is not configured")
-	}
-
-	aiConfigEntity := profile.AI.ToEntity()
-	promptConfigEntity := profile.Prompt.ToEntity()
-
-	recommend, err := r.recommender.Recommend(
-		ctx,
-		aiConfigEntity,
-		promptConfigEntity,
-		allArticles)
+	recommend, err := r.recommender.Recommend(ctx, allArticles)
 	if err != nil {
 		return fmt.Errorf("failed to recommend article: %w", err)
 	}

--- a/cmd/runner/recommend_test.go
+++ b/cmd/runner/recommend_test.go
@@ -134,7 +134,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 				}, nil).Times(1)
 			},
 			mockRecommenderExpectations: func(m *mock_domain.MockRecommender) {
-				m.EXPECT().Recommend(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&entity.Recommend{
+				m.EXPECT().Recommend(gomock.Any(), gomock.Any()).Return(&entity.Recommend{
 					Article: entity.Article{Title: "Recommended Article", Link: "http://example.com/recommended"},
 				}, nil).Times(1)
 			},
@@ -150,7 +150,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 			},
 			mockRecommenderExpectations: func(m *mock_domain.MockRecommender) {
 				// Should not be called if no articles are found
-				m.EXPECT().Recommend(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				m.EXPECT().Recommend(gomock.Any(), gomock.Any()).Times(0)
 			},
 			params: &RecommendParams{
 				URLs: []string{"http://example.com/empty.xml"},
@@ -163,7 +163,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 				m.EXPECT().Fetch(gomock.Any()).Return(nil, fmt.Errorf("mock fetch error")).Times(1)
 			},
 			mockRecommenderExpectations: func(m *mock_domain.MockRecommender) {
-				m.EXPECT().Recommend(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				m.EXPECT().Recommend(gomock.Any(), gomock.Any()).Times(0)
 			},
 			params: &RecommendParams{
 				URLs: []string{"http://invalid.com/feed.xml"},
@@ -178,7 +178,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 				}, nil).Times(1)
 			},
 			mockRecommenderExpectations: func(m *mock_domain.MockRecommender) {
-				m.EXPECT().Recommend(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("mock recommend error")).Times(1)
+				m.EXPECT().Recommend(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("mock recommend error")).Times(1)
 			},
 			params: &RecommendParams{
 				URLs: []string{"http://example.com/feed.xml"},
@@ -192,13 +192,15 @@ func TestRecommendRunner_Run(t *testing.T) {
 					{Title: "Test Article", Link: "http://example.com/test"}}, nil).AnyTimes()
 			},
 			mockRecommenderExpectations: func(m *mock_domain.MockRecommender) {
-				// Recommend is not called if AI model or prompt is not found.
-				m.EXPECT().Recommend(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				// Recommend is called - config is handled by Recommender constructor now.
+				m.EXPECT().Recommend(gomock.Any(), gomock.Any()).Return(&entity.Recommend{
+					Article: entity.Article{Title: "Test Article", Link: "http://example.com/test"},
+				}, nil).Times(1)
 			},
 			params: &RecommendParams{
 				URLs: []string{"http://example.com/feed.xml"},
 			},
-			expectedErrorMessage: toStringP("AI model or prompt is not configured"),
+			expectedErrorMessage: nil,
 		},
 		{
 			name: "Prompt not configured",
@@ -207,13 +209,15 @@ func TestRecommendRunner_Run(t *testing.T) {
 					{Title: "Test Article", Link: "http://example.com/test"}}, nil).AnyTimes()
 			},
 			mockRecommenderExpectations: func(m *mock_domain.MockRecommender) {
-				// Recommend is not called if AI model or prompt is not found.
-				m.EXPECT().Recommend(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+				// Recommend is called - config is handled by Recommender constructor now.
+				m.EXPECT().Recommend(gomock.Any(), gomock.Any()).Return(&entity.Recommend{
+					Article: entity.Article{Title: "Test Article", Link: "http://example.com/test"},
+				}, nil).Times(1)
 			},
 			params: &RecommendParams{
 				URLs: []string{"http://example.com/feed.xml"},
 			},
-			expectedErrorMessage: toStringP("AI model or prompt is not configured"),
+			expectedErrorMessage: nil,
 		},
 	}
 

--- a/internal/domain/message.go
+++ b/internal/domain/message.go
@@ -5,6 +5,5 @@ import (
 )
 
 type MessageSender interface {
-	SendArticles([]entity.Article) error
 	SendRecommend(*entity.Recommend, string) error
 }

--- a/internal/domain/mock_domain/message.go
+++ b/internal/domain/mock_domain/message.go
@@ -40,20 +40,6 @@ func (m *MockMessageSender) EXPECT() *MockMessageSenderMockRecorder {
 	return m.recorder
 }
 
-// SendArticles mocks base method.
-func (m *MockMessageSender) SendArticles(arg0 []entity.Article) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendArticles", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SendArticles indicates an expected call of SendArticles.
-func (mr *MockMessageSenderMockRecorder) SendArticles(arg0 any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendArticles", reflect.TypeOf((*MockMessageSender)(nil).SendArticles), arg0)
-}
-
 // SendRecommend mocks base method.
 func (m *MockMessageSender) SendRecommend(arg0 *entity.Recommend, arg1 string) error {
 	m.ctrl.T.Helper()

--- a/internal/domain/mock_domain/recommend.go
+++ b/internal/domain/mock_domain/recommend.go
@@ -42,16 +42,16 @@ func (m *MockRecommender) EXPECT() *MockRecommenderMockRecorder {
 }
 
 // Recommend mocks base method.
-func (m *MockRecommender) Recommend(arg0 context.Context, arg1 *entity.AIConfig, arg2 *entity.PromptConfig, arg3 []entity.Article) (*entity.Recommend, error) {
+func (m *MockRecommender) Recommend(arg0 context.Context, arg1 []entity.Article) (*entity.Recommend, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Recommend", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "Recommend", arg0, arg1)
 	ret0, _ := ret[0].(*entity.Recommend)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Recommend indicates an expected call of Recommend.
-func (mr *MockRecommenderMockRecorder) Recommend(arg0, arg1, arg2, arg3 any) *gomock.Call {
+func (mr *MockRecommenderMockRecorder) Recommend(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recommend", reflect.TypeOf((*MockRecommender)(nil).Recommend), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recommend", reflect.TypeOf((*MockRecommender)(nil).Recommend), arg0, arg1)
 }

--- a/internal/domain/recommend.go
+++ b/internal/domain/recommend.go
@@ -26,11 +26,7 @@ func NewRandomRecommender(f CommentGeneratorFactory, ai *entity.AIConfig, prompt
 	}
 }
 
-func (r *RandomRecommender) Recommend(
-	ctx context.Context,
-	model *entity.AIConfig,
-	prompt *entity.PromptConfig,
-	articles []entity.Article) (*entity.Recommend, error) {
+func (r *RandomRecommender) Recommend(ctx context.Context, articles []entity.Article) (*entity.Recommend, error) {
 	if len(articles) == 0 {
 		return nil, fmt.Errorf("no articles found")
 	}
@@ -40,8 +36,8 @@ func (r *RandomRecommender) Recommend(
 		Article: article,
 	}
 
-	if (r.factory != nil) && (model != nil) && (prompt != nil) {
-		comment, err := generateComment(r.factory, model, prompt, ctx, &article)
+	if (r.factory != nil) && (r.aiConfig != nil) && (r.promptConfig != nil) {
+		comment, err := generateComment(r.factory, r.aiConfig, r.promptConfig, ctx, &article)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/domain/recommend.go
+++ b/internal/domain/recommend.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Recommender interface {
-	Recommend(context.Context, *entity.AIConfig, *entity.PromptConfig, []entity.Article) (*entity.Recommend, error)
+	Recommend(context.Context, []entity.Article) (*entity.Recommend, error)
 }
 
 type RandomRecommender struct {

--- a/internal/domain/recommend.go
+++ b/internal/domain/recommend.go
@@ -61,17 +61,13 @@ func NewFirstRecommender(f CommentGeneratorFactory, ai *entity.AIConfig, prompt 
 	}
 }
 
-func (r *FirstRecommender) Recommend(
-	ctx context.Context,
-	model *entity.AIConfig,
-	prompt *entity.PromptConfig,
-	articles []entity.Article) (*entity.Recommend, error) {
+func (r *FirstRecommender) Recommend(ctx context.Context, articles []entity.Article) (*entity.Recommend, error) {
 	if len(articles) == 0 {
 		return nil, nil
 	}
 
 	article := articles[0]
-	comment, err := generateComment(r.factory, model, prompt, ctx, &article)
+	comment, err := generateComment(r.factory, r.aiConfig, r.promptConfig, ctx, &article)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/domain/recommend.go
+++ b/internal/domain/recommend.go
@@ -52,12 +52,16 @@ func (r *RandomRecommender) Recommend(
 }
 
 type FirstRecommender struct {
-	factory CommentGeneratorFactory
+	factory      CommentGeneratorFactory
+	aiConfig     *entity.AIConfig
+	promptConfig *entity.PromptConfig
 }
 
-func NewFirstRecommender(f CommentGeneratorFactory) Recommender {
+func NewFirstRecommender(f CommentGeneratorFactory, ai *entity.AIConfig, prompt *entity.PromptConfig) Recommender {
 	return &FirstRecommender{
-		factory: f,
+		factory:      f,
+		aiConfig:     ai,
+		promptConfig: prompt,
 	}
 }
 

--- a/internal/domain/recommend.go
+++ b/internal/domain/recommend.go
@@ -13,12 +13,16 @@ type Recommender interface {
 }
 
 type RandomRecommender struct {
-	factory CommentGeneratorFactory
+	factory      CommentGeneratorFactory
+	aiConfig     *entity.AIConfig
+	promptConfig *entity.PromptConfig
 }
 
-func NewRandomRecommender(f CommentGeneratorFactory) Recommender {
+func NewRandomRecommender(f CommentGeneratorFactory, ai *entity.AIConfig, prompt *entity.PromptConfig) Recommender {
 	return &RandomRecommender{
-		factory: f,
+		factory:      f,
+		aiConfig:     ai,
+		promptConfig: prompt,
 	}
 }
 

--- a/internal/infra/message/misskey.go
+++ b/internal/infra/message/misskey.go
@@ -37,11 +37,6 @@ func NewMisskeySender(instanceURL, accessToken string) (domain.MessageSender, er
 	return &MisskeySender{client: client}, nil
 }
 
-// SendArticles はMisskeySenderでは未実装です。
-func (v *MisskeySender) SendArticles(articles []entity.Article) error {
-	return nil
-}
-
 // SendRecommend はMisskeyにノートを投稿します。
 func (v *MisskeySender) SendRecommend(recommend *entity.Recommend, fixedMessage string) error {
 	if recommend == nil {

--- a/internal/infra/message/slack.go
+++ b/internal/infra/message/slack.go
@@ -44,11 +44,6 @@ func NewSlackSender(config *entity.SlackAPIConfig) domain.MessageSender {
 	}
 }
 
-func (s *SlackSender) SendArticles(articles []entity.Article) error {
-	// TODO 実装
-	return nil
-}
-
 func (v *SlackSender) SendRecommend(recommend *entity.Recommend, fixedMessage string) error {
 	// テンプレートデータを作成
 	templateData := &SlackTemplateData{

--- a/internal/infra/message/std.go
+++ b/internal/infra/message/std.go
@@ -43,20 +43,6 @@ func NewStdSender(writer io.Writer) (domain.MessageSender, error) {
 	}, nil
 }
 
-// SendArticles は記事のリストを表示する
-func (v *StdSender) SendArticles(articles []entity.Article) error {
-	for _, article := range articles {
-		fmt.Fprintf(v.writer, "Title: %s\n", article.Title)
-		fmt.Fprintf(v.writer, "Link: %s\n", article.Link)
-		if article.Published != nil {
-			fmt.Fprintf(v.writer, "Published: %s\n", article.Published.In(v.loc).Format("2006-01-02 15:04:05 JST"))
-		}
-		fmt.Fprintf(v.writer, "Content: %s\n", article.Content)
-		fmt.Fprintln(v.writer, "---")
-	}
-	return nil
-}
-
 // SendRecommend は推薦記事を表示する
 func (v *StdSender) SendRecommend(recommend *entity.Recommend, fixedMessage string) error {
 	if recommend == nil {


### PR DESCRIPTION
## Summary
- MessageSenderからSendArticles関数を削除（未使用のため）
- RecommenderインターフェースのRecommend関数からAIConfigとPromptConfigの引数を削除
- ConfigをRecommenderのコンストラクタで受け取るように変更

## Test plan
- [x] make build が成功する
- [x] make test が成功する
- [x] make lint が成功する
- [x] 既存機能が正常に動作する

🤖 Generated with [Claude Code](https://claude.ai/code)

fixed #91