### PR TITLE
apiキーやトークンを環境変数から読み込めるようにする (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AI Feedは、指定されたURLから記事をプレビューしたり、AIが�
 
 3. config.ymlを編集
     - geminiのtypeにはモデルのバージョンを指定。具体的な値は[参考リンク](https://ai.google.dev/gemini-api/docs/models?hl=ja#model-versions)を参照。
+    - APIキー・トークンの設定方法は[APIキーの設定](#apiキーの設定)を参照。
     - 投稿文に固定文言を付与しないなら fixed_message の行を削除。
     - slackへの投稿を行わないなら slack_api のブロックを削除。
     - misskeyへの投稿を行わないなら misskey のブロックを削除。
@@ -148,3 +149,71 @@ make run option="profile init my_profile.yml"
 ```bash
 make run option="config init"
 ```
+
+## APIキーの設定
+
+AI FeedでAPIキーやトークンを設定する方法は2つあります：
+
+### 方法1: ファイルに直接記述
+
+config.ymlやprofile.ymlファイルに直接APIキーを記述する方法です。
+
+```yaml
+# config.ymlの例
+ai:
+  gemini:
+    api_key: your_actual_gemini_api_key_here
+
+output:
+  slack_api:
+    api_token: your_actual_slack_token_here
+  misskey:
+    api_token: your_actual_misskey_token_here
+```
+
+### 方法2: 環境変数から取得（推奨）
+
+セキュリティ上の理由から、APIキーを環境変数から取得する方法を推奨します。
+
+```yaml
+# config.ymlまたはprofile.ymlの例
+ai:
+  gemini:
+    api_key_env: GEMINI_API_KEY  # 環境変数名を指定
+
+output:
+  slack_api:
+    api_token_env: SLACK_TOKEN  # 環境変数名を指定
+  misskey:
+    api_token_env: MISSKEY_TOKEN  # 環境変数名を指定
+```
+
+環境変数の設定例：
+```bash
+# 環境変数を設定
+export GEMINI_API_KEY="your_actual_gemini_api_key_here"
+export SLACK_TOKEN="your_actual_slack_token_here"
+export MISSKEY_TOKEN="your_actual_misskey_token_here"
+
+# ai-feedを実行
+./ai-feed recommend --url https://example.com/feed.xml
+```
+
+### 優先順位
+
+両方の設定方法を併用した場合の優先順位：
+
+1. **直接指定が最優先**: `api_key`や`api_token`が設定されている場合、環境変数の設定は無視されます
+2. **環境変数**: 直接指定がない場合、環境変数から取得します
+3. **エラー**: 直接指定も環境変数もない場合はエラーになります
+
+### エラー対応
+
+環境変数が設定されていない場合、以下のようなエラーが表示されます：
+
+```
+Profile validation failed:
+  ERROR: 環境変数 'GEMINI_API_KEY' が設定されていません。ai.gemini.api_key_env で指定された環境変数を設定してください。
+```
+
+このエラーが発生した場合は、指定された環境変数名で正しくAPIキーが設定されているかを確認してください。

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -104,7 +104,10 @@ func makeProfileCheckCmd() *cobra.Command {
 			}
 
 			// マージ後のプロファイルをentity.Profileに変換してバリデーション
-			entityProfile := currentProfile.ToEntity()
+			entityProfile, err := currentProfile.ToEntity()
+			if err != nil {
+				return fmt.Errorf("failed to process profile: %w", err)
+			}
 			result := entityProfile.Validate()
 
 			// 結果の表示

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -99,8 +99,14 @@ func makeProfileCheckCmd() *cobra.Command {
 					return err
 				}
 
-				// デフォルトプロファイルとマージ
-				currentProfile.Merge(loadedInfraProfile)
+				// config.ymlが存在する場合はマージ、存在しない場合はloadedInfraProfileをそのまま使用
+				if config != nil && config.DefaultProfile != nil {
+					// デフォルトプロファイルとマージ
+					currentProfile.Merge(loadedInfraProfile)
+				} else {
+					// config.ymlが存在しない場合は、読み込んだプロファイルをそのまま使用
+					currentProfile = *loadedInfraProfile
+				}
 			}
 
 			// マージ後のプロファイルをentity.Profileに変換してバリデーション

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -51,7 +51,11 @@ recommends one random article from the fetched list.`,
 			// AIConfig と PromptConfig を取得
 			var aiConfigEntity *entity.AIConfig
 			if currentProfile.AI != nil {
-				aiConfigEntity = currentProfile.AI.ToEntity()
+				var err error
+				aiConfigEntity, err = currentProfile.AI.ToEntity()
+				if err != nil {
+					return fmt.Errorf("failed to process AI config: %w", err)
+				}
 			}
 
 			var promptConfigEntity *entity.PromptConfig

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -43,11 +43,19 @@ func NewRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 
 	if outputConfig != nil {
 		if outputConfig.SlackAPI != nil {
-			slackViewer := message.NewSlackSender(outputConfig.SlackAPI.ToEntity())
+			slackConfig, err := outputConfig.SlackAPI.ToEntity()
+			if err != nil {
+				return nil, fmt.Errorf("failed to process Slack API config: %w", err)
+			}
+			slackViewer := message.NewSlackSender(slackConfig)
 			viewers = append(viewers, slackViewer)
 		}
 		if outputConfig.Misskey != nil {
-			misskeyViewer, err := message.NewMisskeySender(outputConfig.Misskey.APIURL, outputConfig.Misskey.APIToken)
+			misskeyConfig, err := outputConfig.Misskey.ToEntity()
+			if err != nil {
+				return nil, fmt.Errorf("failed to process Misskey config: %w", err)
+			}
+			misskeyViewer, err := message.NewMisskeySender(misskeyConfig.APIURL, misskeyConfig.APIToken)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create Misskey viewer: %w", err)
 			}

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -13,7 +13,6 @@ var templateCache sync.Map
 
 // デフォルト値の定数
 
-
 type AIConfig struct {
 	Gemini *GeminiConfig
 }

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -12,11 +12,7 @@ import (
 var templateCache sync.Map
 
 // デフォルト値の定数
-const (
-	DefaultGeminiAPIKey    = "YOUR_GEMINI_API_KEY_HERE"
-	DefaultSlackAPIToken   = "xoxb-YOUR_SLACK_API_TOKEN_HERE"
-	DefaultMisskeyAPIToken = "YOUR_MISSKEY_PUBLIC_API_TOKEN_HERE"
-)
+
 
 type AIConfig struct {
 	Gemini *GeminiConfig
@@ -52,7 +48,7 @@ func (g *GeminiConfig) Validate() *ValidationResult {
 	}
 
 	// APIKey: 必須項目（空文字列でない）
-	if err := ValidateRequiredWithDefault(g.APIKey, DefaultGeminiAPIKey, "Gemini API key"); err != nil {
+	if err := ValidateRequired(g.APIKey, "Gemini API key"); err != nil {
 		builder.AddError(err.Error())
 	}
 
@@ -128,7 +124,7 @@ func (m *MisskeyConfig) Validate() *ValidationResult {
 	builder := NewValidationBuilder()
 
 	// APIToken: 必須項目（空文字列でない）
-	if err := ValidateRequiredWithDefault(m.APIToken, DefaultMisskeyAPIToken, "Misskey APIトークン"); err != nil {
+	if err := ValidateRequired(m.APIToken, "Misskey APIトークン"); err != nil {
 		builder.AddError(err.Error())
 	}
 
@@ -151,7 +147,7 @@ func (s *SlackAPIConfig) Validate() *ValidationResult {
 	builder := NewValidationBuilder()
 
 	// APIToken: 必須項目（空文字列でない）
-	if err := ValidateRequiredWithDefault(s.APIToken, DefaultSlackAPIToken, "Slack APIトークン"); err != nil {
+	if err := ValidateRequired(s.APIToken, "Slack APIトークン"); err != nil {
 		builder.AddError(err.Error())
 	}
 

--- a/internal/domain/entity/config_test.go
+++ b/internal/domain/entity/config_test.go
@@ -39,15 +39,6 @@ func TestGeminiConfig_Validate(t *testing.T) {
 			wantErr: true,
 			errors:  []string{"Gemini API keyが設定されていません"},
 		},
-		{
-			name: "異常系_APIKeyがデフォルト値",
-			config: &GeminiConfig{
-				Type:   "gemini-pro",
-				APIKey: DefaultGeminiAPIKey,
-			},
-			wantErr: true,
-			errors:  []string{"Gemini API keyが設定されていません"},
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/domain/entity/validation_utils.go
+++ b/internal/domain/entity/validation_utils.go
@@ -59,13 +59,7 @@ func ValidateRequired(value, fieldName string) error {
 	return nil
 }
 
-// ValidateRequiredWithDefault は必須項目がデフォルト値でないことを検証する
-func ValidateRequiredWithDefault(value, defaultValue, fieldName string) error {
-	if value == "" || value == defaultValue {
-		return fmt.Errorf("%sが設定されていません", fieldName)
-	}
-	return nil
-}
+
 
 // ValidateURL はURLが正しい形式であることを検証する
 func ValidateURL(urlStr, fieldName string) error {

--- a/internal/domain/entity/validation_utils.go
+++ b/internal/domain/entity/validation_utils.go
@@ -59,8 +59,6 @@ func ValidateRequired(value, fieldName string) error {
 	return nil
 }
 
-
-
 // ValidateURL はURLが正しい形式であることを検証する
 func ValidateURL(urlStr, fieldName string) error {
 	if urlStr == "" {

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -74,8 +74,9 @@ func (c *AIConfig) ToEntity() *entity.AIConfig {
 }
 
 type GeminiConfig struct {
-	Type   string `yaml:"type"`
-	APIKey string `yaml:"api_key"`
+	Type      string `yaml:"type"`
+	APIKey    string `yaml:"api_key"`
+	APIKeyEnv string `yaml:"api_key_env,omitempty"`
 }
 
 func (c *GeminiConfig) Merge(other *GeminiConfig) {
@@ -148,6 +149,7 @@ func (c *OutputConfig) ToEntity() *entity.OutputConfig {
 
 type SlackAPIConfig struct {
 	APIToken        string  `yaml:"api_token"`
+	APITokenEnv     string  `yaml:"api_token_env,omitempty"`
 	Channel         string  `yaml:"channel"`
 	MessageTemplate *string `yaml:"message_template,omitempty"`
 }
@@ -172,8 +174,9 @@ func (c *SlackAPIConfig) ToEntity() *entity.SlackAPIConfig {
 }
 
 type MisskeyConfig struct {
-	APIToken string `yaml:"api_token"`
-	APIURL   string `yaml:"api_url"`
+	APIToken    string `yaml:"api_token"`
+	APITokenEnv string `yaml:"api_token_env,omitempty"`
+	APIURL      string `yaml:"api_url"`
 }
 
 func (c *MisskeyConfig) Merge(other *MisskeyConfig) {

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -97,11 +97,12 @@ func (c *GeminiConfig) Merge(other *GeminiConfig) {
 	}
 	mergeString(&c.Type, other.Type)
 	mergeString(&c.APIKey, other.APIKey)
+	mergeString(&c.APIKeyEnv, other.APIKeyEnv)
 }
 
 func (c *GeminiConfig) ToEntity() (*entity.GeminiConfig, error) {
 	apiKey := c.APIKey
-	
+
 	// APIKeyが空でAPIKeyEnvが指定されている場合、環境変数から取得
 	if apiKey == "" && c.APIKeyEnv != "" {
 		envValue := os.Getenv(c.APIKeyEnv)
@@ -110,7 +111,7 @@ func (c *GeminiConfig) ToEntity() (*entity.GeminiConfig, error) {
 		}
 		apiKey = envValue
 	}
-	
+
 	return &entity.GeminiConfig{
 		Type:   c.Type,
 		APIKey: apiKey,
@@ -190,6 +191,7 @@ func (c *SlackAPIConfig) Merge(other *SlackAPIConfig) {
 		return
 	}
 	mergeString(&c.APIToken, other.APIToken)
+	mergeString(&c.APITokenEnv, other.APITokenEnv)
 	mergeString(&c.Channel, other.Channel)
 	if other.MessageTemplate != nil {
 		c.MessageTemplate = other.MessageTemplate
@@ -198,7 +200,7 @@ func (c *SlackAPIConfig) Merge(other *SlackAPIConfig) {
 
 func (c *SlackAPIConfig) ToEntity() (*entity.SlackAPIConfig, error) {
 	apiToken := c.APIToken
-	
+
 	// APITokenが空でAPITokenEnvが指定されている場合、環境変数から取得
 	if apiToken == "" && c.APITokenEnv != "" {
 		envValue := os.Getenv(c.APITokenEnv)
@@ -207,7 +209,7 @@ func (c *SlackAPIConfig) ToEntity() (*entity.SlackAPIConfig, error) {
 		}
 		apiToken = envValue
 	}
-	
+
 	return &entity.SlackAPIConfig{
 		APIToken:        apiToken,
 		Channel:         c.Channel,
@@ -226,12 +228,13 @@ func (c *MisskeyConfig) Merge(other *MisskeyConfig) {
 		return
 	}
 	mergeString(&c.APIToken, other.APIToken)
+	mergeString(&c.APITokenEnv, other.APITokenEnv)
 	mergeString(&c.APIURL, other.APIURL)
 }
 
 func (c *MisskeyConfig) ToEntity() (*entity.MisskeyConfig, error) {
 	apiToken := c.APIToken
-	
+
 	// APITokenが空でAPITokenEnvが指定されている場合、環境変数から取得
 	if apiToken == "" && c.APITokenEnv != "" {
 		envValue := os.Getenv(c.APITokenEnv)
@@ -240,7 +243,7 @@ func (c *MisskeyConfig) ToEntity() (*entity.MisskeyConfig, error) {
 		}
 		apiToken = envValue
 	}
-	
+
 	return &entity.MisskeyConfig{
 		APIToken: apiToken,
 		APIURL:   c.APIURL,

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -250,39 +250,6 @@ func (c *MisskeyConfig) ToEntity() (*entity.MisskeyConfig, error) {
 	}, nil
 }
 
-func MakeDefaultConfig() *Config {
-	return &Config{
-		DefaultProfile: &Profile{
-			AI: &AIConfig{
-				Gemini: &GeminiConfig{
-					Type:   "gemini-1.5-flash",
-					APIKey: "xxxxxx",
-				},
-			},
-			Prompt: &PromptConfig{
-				SystemPrompt: "あなたはXXXXなAIアシスタントです。",
-				CommentPromptTemplate: `以下の記事の紹介文を100字以内で作成してください。
----
-記事タイトル: {{title}}
-記事URL: {{url}}
-記事内容:
-{{content}}`,
-				FixedMessage: "固定の文言です。",
-			},
-			Output: &OutputConfig{
-				SlackAPI: &SlackAPIConfig{
-					APIToken: "xoxb-xxxxxx",
-					Channel:  "#general",
-				},
-				Misskey: &MisskeyConfig{
-					APIToken: "YOUR_MISSKEY_PUBLIC_API_TOKEN_HERE",
-					APIURL:   "https://misskey.social/api",
-				},
-			},
-		},
-	}
-}
-
 type ConfigRepository interface {
 	Save(config *Config) error
 	Load() (*Config, error)

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -96,8 +96,17 @@ func (c *GeminiConfig) Merge(other *GeminiConfig) {
 		return
 	}
 	mergeString(&c.Type, other.Type)
-	mergeString(&c.APIKey, other.APIKey)
-	mergeString(&c.APIKeyEnv, other.APIKeyEnv)
+
+	// プロファイルファイルでapi_key_envが指定されている場合、
+	// デフォルトのapi_keyを無効にして環境変数を優先する
+	if other.APIKeyEnv != "" && other.APIKey == "" {
+		c.APIKey = ""
+		c.APIKeyEnv = other.APIKeyEnv
+	} else {
+		// 通常のマージ処理
+		mergeString(&c.APIKey, other.APIKey)
+		mergeString(&c.APIKeyEnv, other.APIKeyEnv)
+	}
 }
 
 // resolveSecret は、直接指定された値または環境変数から値を解決する
@@ -199,8 +208,18 @@ func (c *SlackAPIConfig) Merge(other *SlackAPIConfig) {
 	if other == nil {
 		return
 	}
-	mergeString(&c.APIToken, other.APIToken)
-	mergeString(&c.APITokenEnv, other.APITokenEnv)
+
+	// プロファイルファイルでapi_token_envが指定されている場合、
+	// デフォルトのapi_tokenを無効にして環境変数を優先する
+	if other.APITokenEnv != "" && other.APIToken == "" {
+		c.APIToken = ""
+		c.APITokenEnv = other.APITokenEnv
+	} else {
+		// 通常のマージ処理
+		mergeString(&c.APIToken, other.APIToken)
+		mergeString(&c.APITokenEnv, other.APITokenEnv)
+	}
+
 	mergeString(&c.Channel, other.Channel)
 	if other.MessageTemplate != nil {
 		c.MessageTemplate = other.MessageTemplate
@@ -230,8 +249,18 @@ func (c *MisskeyConfig) Merge(other *MisskeyConfig) {
 	if other == nil {
 		return
 	}
-	mergeString(&c.APIToken, other.APIToken)
-	mergeString(&c.APITokenEnv, other.APITokenEnv)
+
+	// プロファイルファイルでapi_token_envが指定されている場合、
+	// デフォルトのapi_tokenを無効にして環境変数を優先する
+	if other.APITokenEnv != "" && other.APIToken == "" {
+		c.APIToken = ""
+		c.APITokenEnv = other.APITokenEnv
+	} else {
+		// 通常のマージ処理
+		mergeString(&c.APIToken, other.APIToken)
+		mergeString(&c.APITokenEnv, other.APITokenEnv)
+	}
+
 	mergeString(&c.APIURL, other.APIURL)
 }
 

--- a/internal/infra/config_test.go
+++ b/internal/infra/config_test.go
@@ -76,7 +76,16 @@ func TestYamlConfigRepository_Save_InvalidPath(t *testing.T) {
 	invalidPath := "/nonexistent_dir/test_config.yaml" // This path should not exist and cause an error
 	repo := NewYamlConfigRepository(invalidPath)
 
-	configToSave := MakeDefaultConfig()
+	configToSave := &Config{
+		DefaultProfile: &Profile{
+			AI: &AIConfig{
+				Gemini: &GeminiConfig{
+					Type:   "gemini-test",
+					APIKey: "test-api-key",
+				},
+			},
+		},
+	}
 	err := repo.Save(configToSave)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create config file")

--- a/internal/infra/config_test.go
+++ b/internal/infra/config_test.go
@@ -209,3 +209,255 @@ func TestOutputConfig_MarshalYAML(t *testing.T) {
 		})
 	}
 }
+
+// 環境変数からのAPIキー/トークン取得機能のテスト
+
+func TestGeminiConfig_ToEntity_WithEnvironmentVariable(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        GeminiConfig
+		envVar        string
+		envValue      string
+		expectedError string
+	}{
+		{
+			name: "APIKey直接指定優先",
+			config: GeminiConfig{
+				Type:      "gemini-test",
+				APIKey:    "direct-key",
+				APIKeyEnv: "TEST_GEMINI_KEY",
+			},
+			envVar:        "TEST_GEMINI_KEY",
+			envValue:      "env-key",
+			expectedError: "",
+		},
+		{
+			name: "環境変数から取得成功",
+			config: GeminiConfig{
+				Type:      "gemini-test",
+				APIKey:    "",
+				APIKeyEnv: "TEST_GEMINI_KEY",
+			},
+			envVar:        "TEST_GEMINI_KEY",
+			envValue:      "env-key-value",
+			expectedError: "",
+		},
+		{
+			name: "環境変数が存在しない",
+			config: GeminiConfig{
+				Type:      "gemini-test",
+				APIKey:    "",
+				APIKeyEnv: "NON_EXISTENT_KEY",
+			},
+			envVar:        "",
+			envValue:      "",
+			expectedError: "環境変数 'NON_EXISTENT_KEY' が設定されていません",
+		},
+		{
+			name: "環境変数が空文字列",
+			config: GeminiConfig{
+				Type:      "gemini-test",
+				APIKey:    "",
+				APIKeyEnv: "EMPTY_GEMINI_KEY",
+			},
+			envVar:        "EMPTY_GEMINI_KEY",
+			envValue:      "",
+			expectedError: "環境変数 'EMPTY_GEMINI_KEY' が設定されていません",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv(tt.envVar, tt.envValue)
+			}
+
+			entity, err := tt.config.ToEntity()
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, entity)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, entity)
+				assert.Equal(t, tt.config.Type, entity.Type)
+
+				if tt.config.APIKey != "" {
+					// 直接指定が優先される
+					assert.Equal(t, tt.config.APIKey, entity.APIKey)
+				} else {
+					// 環境変数から取得
+					assert.Equal(t, tt.envValue, entity.APIKey)
+				}
+			}
+		})
+	}
+}
+
+func TestSlackAPIConfig_ToEntity_WithEnvironmentVariable(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        SlackAPIConfig
+		envVar        string
+		envValue      string
+		expectedError string
+	}{
+		{
+			name: "APIToken直接指定優先",
+			config: SlackAPIConfig{
+				APIToken:    "direct-token",
+				APITokenEnv: "TEST_SLACK_TOKEN",
+				Channel:     "#test",
+			},
+			envVar:        "TEST_SLACK_TOKEN",
+			envValue:      "env-token",
+			expectedError: "",
+		},
+		{
+			name: "環境変数から取得成功",
+			config: SlackAPIConfig{
+				APIToken:    "",
+				APITokenEnv: "TEST_SLACK_TOKEN",
+				Channel:     "#test",
+			},
+			envVar:        "TEST_SLACK_TOKEN",
+			envValue:      "env-token-value",
+			expectedError: "",
+		},
+		{
+			name: "環境変数が存在しない",
+			config: SlackAPIConfig{
+				APIToken:    "",
+				APITokenEnv: "NON_EXISTENT_SLACK",
+				Channel:     "#test",
+			},
+			envVar:        "",
+			envValue:      "",
+			expectedError: "環境変数 'NON_EXISTENT_SLACK' が設定されていません",
+		},
+		{
+			name: "環境変数が空文字列",
+			config: SlackAPIConfig{
+				APIToken:    "",
+				APITokenEnv: "EMPTY_SLACK_TOKEN",
+				Channel:     "#test",
+			},
+			envVar:        "EMPTY_SLACK_TOKEN",
+			envValue:      "",
+			expectedError: "環境変数 'EMPTY_SLACK_TOKEN' が設定されていません",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv(tt.envVar, tt.envValue)
+			}
+
+			entity, err := tt.config.ToEntity()
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, entity)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, entity)
+				assert.Equal(t, tt.config.Channel, entity.Channel)
+				assert.Equal(t, tt.config.MessageTemplate, entity.MessageTemplate)
+
+				if tt.config.APIToken != "" {
+					// 直接指定が優先される
+					assert.Equal(t, tt.config.APIToken, entity.APIToken)
+				} else {
+					// 環境変数から取得
+					assert.Equal(t, tt.envValue, entity.APIToken)
+				}
+			}
+		})
+	}
+}
+
+func TestMisskeyConfig_ToEntity_WithEnvironmentVariable(t *testing.T) {
+	tests := []struct {
+		name          string
+		config        MisskeyConfig
+		envVar        string
+		envValue      string
+		expectedError string
+	}{
+		{
+			name: "APIToken直接指定優先",
+			config: MisskeyConfig{
+				APIToken:    "direct-token",
+				APITokenEnv: "TEST_MISSKEY_TOKEN",
+				APIURL:      "https://test.misskey.com",
+			},
+			envVar:        "TEST_MISSKEY_TOKEN",
+			envValue:      "env-token",
+			expectedError: "",
+		},
+		{
+			name: "環境変数から取得成功",
+			config: MisskeyConfig{
+				APIToken:    "",
+				APITokenEnv: "TEST_MISSKEY_TOKEN",
+				APIURL:      "https://test.misskey.com",
+			},
+			envVar:        "TEST_MISSKEY_TOKEN",
+			envValue:      "env-token-value",
+			expectedError: "",
+		},
+		{
+			name: "環境変数が存在しない",
+			config: MisskeyConfig{
+				APIToken:    "",
+				APITokenEnv: "NON_EXISTENT_MISSKEY",
+				APIURL:      "https://test.misskey.com",
+			},
+			envVar:        "",
+			envValue:      "",
+			expectedError: "環境変数 'NON_EXISTENT_MISSKEY' が設定されていません",
+		},
+		{
+			name: "環境変数が空文字列",
+			config: MisskeyConfig{
+				APIToken:    "",
+				APITokenEnv: "EMPTY_MISSKEY_TOKEN",
+				APIURL:      "https://test.misskey.com",
+			},
+			envVar:        "EMPTY_MISSKEY_TOKEN",
+			envValue:      "",
+			expectedError: "環境変数 'EMPTY_MISSKEY_TOKEN' が設定されていません",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envVar != "" {
+				t.Setenv(tt.envVar, tt.envValue)
+			}
+
+			entity, err := tt.config.ToEntity()
+
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				assert.Nil(t, entity)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, entity)
+				assert.Equal(t, tt.config.APIURL, entity.APIURL)
+
+				if tt.config.APIToken != "" {
+					// 直接指定が優先される
+					assert.Equal(t, tt.config.APIToken, entity.APIToken)
+				} else {
+					// 環境変数から取得
+					assert.Equal(t, tt.envValue, entity.APIToken)
+				}
+			}
+		})
+	}
+}

--- a/internal/infra/profile/repository.go
+++ b/internal/infra/profile/repository.go
@@ -35,7 +35,7 @@ func (r *YamlProfileRepository) LoadProfile() (*entity.Profile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return infraProfile.ToEntity(), nil
+	return infraProfile.ToEntity()
 }
 
 // LoadInfraProfile はプロファイルをファイルから読み込み、infra.Profileを返す（内部実装用）

--- a/internal/infra/templates/config.yml
+++ b/internal/infra/templates/config.yml
@@ -6,6 +6,8 @@ default_profile:
     gemini:
       type: gemini-2.5-flash                  # 使用するGeminiモデル
       api_key: xxxxxx                         # Google AI Studio APIキー
+      # api_key_env: GEMINI_API_KEY           # 環境変数からAPIキーを取得する場合
+      # 注意: api_keyとapi_key_envの両方が指定された場合、api_keyが優先されます
 
   # プロンプト設定
   system_prompt: あなたはXXXXなAIアシスタントです。    # AIに与えるシステムプロンプト
@@ -30,6 +32,8 @@ default_profile:
     # Slack投稿設定
     slack_api:
       api_token: xxxxxx                       # Slack Bot Token
+      # api_token_env: SLACK_TOKEN            # 環境変数からトークンを取得する場合
+      # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
       channel: "#general"                     # 投稿先チャンネル
       
       # Slackメッセージテンプレート（オプション）
@@ -51,4 +55,6 @@ default_profile:
     # Misskey投稿設定
     misskey:
       api_token: xxxxxx                       # Misskeyアクセストークン
+      # api_token_env: MISSKEY_TOKEN          # 環境変数からトークンを取得する場合
+      # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
       api_url: https://misskey.social/api     # MisskeyのAPIエンドポイント

--- a/internal/infra/templates/config.yml
+++ b/internal/infra/templates/config.yml
@@ -57,4 +57,4 @@ default_profile:
       api_token: xxxxxx                       # Misskeyアクセストークン
       # api_token_env: MISSKEY_TOKEN          # 環境変数からトークンを取得する場合
       # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
-      api_url: https://misskey.social/api     # MisskeyのAPIエンドポイント
+      api_url: https://example.com            # MisskeyのAPIエンドポイント

--- a/internal/infra/templates/profile.yml
+++ b/internal/infra/templates/profile.yml
@@ -6,6 +6,8 @@ ai:
   gemini:
     type: gemini-2.5-flash                  # 使用するGeminiモデル
     api_key: xxxxxx                         # Google AI Studio APIキー
+    # api_key_env: GEMINI_API_KEY           # 環境変数からAPIキーを取得する場合
+    # 注意: api_keyとapi_key_envの両方が指定された場合、api_keyが優先されます
 
 # プロンプト設定
 system_prompt: あなたはXXXXなAIアシスタントです。    # AIに与えるシステムプロンプト
@@ -30,6 +32,8 @@ output:
   # Slack投稿設定
   slack_api:
     api_token: xxxxxx                       # Slack Bot Token
+    # api_token_env: SLACK_TOKEN            # 環境変数からトークンを取得する場合
+    # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
     channel: "#general"                     # 投稿先チャンネル
     
     # Slackメッセージテンプレート（オプション）
@@ -51,4 +55,6 @@ output:
   # Misskey投稿設定
   misskey:
     api_token: xxxxxx                       # Misskeyアクセストークン
-    api_url: https://misskey.social/api     # MisskeyのAPIエンドポイント
+    # api_token_env: MISSKEY_TOKEN          # 環境変数からトークンを取得する場合
+    # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
+    api_url: https://example.com            # MisskeyのAPIエンドポイント


### PR DESCRIPTION
## Summary
- APIキー・トークンを環境変数から取得できる機能を追加
- セキュリティ向上のため直接記述と環境変数の両方をサポート
- 設定テンプレートに環境変数使用例を追加

## Implementation Details
- infra層構造体に`api_key_env`、`api_token_env`フィールドを追加
- ToEntityメソッドで環境変数読み込み機能を実装
- 直接指定が環境変数より優先される仕様
- 環境変数未設定時の適切なエラーメッセージを日本語で実装

## Changes
- ✅ infra層構造体フィールド追加 (GeminiConfig, SlackAPIConfig, MisskeyConfig)
- ✅ 環境変数読み込み処理実装 (ToEntityメソッド)
- ✅ デフォルト値削除とバリデーション修正
- ✅ 設定テンプレート更新 (config.yml, profile.yml)
- ✅ 包括的なユニットテスト追加
- ✅ README.md詳細説明追加
- ✅ Mergeメソッド修正
- ✅ テンプレート統一 (Misskey URL)

## Test Results
- ✅ 全ユニットテスト正常通過
- ✅ リントエラーなし
- ✅ 環境変数機能動作確認済み

## Usage Example
```yaml
# 環境変数から取得
ai:
  gemini:
    api_key_env: GEMINI_API_KEY

output:
  slack_api:
    api_token_env: SLACK_TOKEN
```

fixed #97

🤖 Generated with [Claude Code](https://claude.ai/code)