### PR TITLE
テンプレートの埋め込みパラメータを分かりやすい名前で指定可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,51 @@ make run option="profile init my_profile.yml"
 make run option="config init"
 ```
 
+## テンプレート記法
+
+profile.ymlの設定でメッセージテンプレートを定義する際に、記事情報を動的に埋め込むためのテンプレート記法を使用できます。
+
+### 基本的な記法
+
+従来の記法（ドット記法）と新しい別名記法の両方がサポートされています：
+
+| データ | 従来記法 | 別名記法 |
+|--------|----------|----------|
+| 記事タイトル | `{{.Title}}` または `{{.Article.Title}}` | `{{TITLE}}` |
+| 記事URL | `{{.Link}}` または `{{.Article.Link}}` | `{{URL}}` |
+| 記事内容 | `{{.Content}}` または `{{.Article.Content}}` | `{{CONTENT}}` |
+| AIコメント | `{{.Comment}}` | `{{COMMENT}}` |
+| 固定メッセージ | `{{.FixedMessage}}` | `{{FIXED_MESSAGE}}` |
+
+### 使用例
+
+```yaml
+# PromptConfig での使用例
+comment_prompt_template: |
+  以下の記事について簡潔に紹介してください：
+  タイトル: {{TITLE}}
+  URL: {{URL}}
+  内容: {{CONTENT}}
+
+# SlackAPI での使用例
+output:
+  slack_api:
+    message_template: |
+      📰 おすすめ記事
+      {{TITLE}}
+      {{URL}}
+      {{if .Comment}}
+      💬 {{COMMENT}}
+      {{end}}
+```
+
+### 注意事項
+
+- **別名記法**: 大文字のみ使用可能（例: `{{TITLE}}`は正しいが、`{{title}}`や`{{Title}}`はエラー）
+- **後方互換性**: 既存の記法も引き続き使用可能
+- **混在可能**: 同一テンプレート内で新旧記法を混在させることも可能
+- **条件分岐**: `{{if .Comment}}`などの制御構文も使用可能
+
 ## APIキーの設定
 
 AI FeedでAPIキーやトークンを設定する方法は2つあります：

--- a/internal/domain/entity/template_alias.go
+++ b/internal/domain/entity/template_alias.go
@@ -3,6 +3,7 @@ package entity
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -137,13 +138,7 @@ func isTemplateControl(s string) bool {
 	}
 
 	firstWord := strings.ToLower(parts[0])
-	for _, control := range controls {
-		if firstWord == control {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(controls, firstWord)
 }
 
 // getValidAliases は使用可能な別名のリストを返す
@@ -154,4 +149,3 @@ func (c *TemplateAliasConverter) getValidAliases() []string {
 	}
 	return aliases
 }
-

--- a/internal/domain/entity/template_alias.go
+++ b/internal/domain/entity/template_alias.go
@@ -1,0 +1,157 @@
+package entity
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// TemplateAliasConverter はテンプレートの別名を既存記法に変換する構造体
+type TemplateAliasConverter struct {
+	// aliasMap は別名から既存記法へのマッピング
+	aliasMap map[string]string
+	// aliasPattern は別名記法を検出する正規表現
+	aliasPattern *regexp.Regexp
+}
+
+// NewPromptTemplateAliasConverter はPromptConfig用の別名変換器を作成する
+func NewPromptTemplateAliasConverter() *TemplateAliasConverter {
+	return &TemplateAliasConverter{
+		aliasMap: map[string]string{
+			"TITLE":   ".Title",
+			"URL":     ".Link",
+			"CONTENT": ".Content",
+		},
+		// 大文字のみの別名を検出するパターン
+		aliasPattern: regexp.MustCompile(`\{\{([A-Z_]+)\}\}`),
+	}
+}
+
+// NewSlackTemplateAliasConverter はSlackAPIConfig用の別名変換器を作成する
+func NewSlackTemplateAliasConverter() *TemplateAliasConverter {
+	return &TemplateAliasConverter{
+		aliasMap: map[string]string{
+			"TITLE":         ".Article.Title",
+			"URL":           ".Article.Link",
+			"CONTENT":       ".Article.Content",
+			"COMMENT":       ".Comment",
+			"FIXED_MESSAGE": ".FixedMessage",
+		},
+		// 大文字のみの別名を検出するパターン
+		aliasPattern: regexp.MustCompile(`\{\{([A-Z_]+)\}\}`),
+	}
+}
+
+// TemplateAliasError はテンプレート別名変換のエラー
+type TemplateAliasError struct {
+	InvalidAlias string
+	Message      string
+}
+
+func (e *TemplateAliasError) Error() string {
+	return e.Message
+}
+
+// Convert はテンプレート文字列内の別名を既存記法に変換する
+func (c *TemplateAliasConverter) Convert(template string) (string, error) {
+	// 既存記法（{{.で始まるもの）はそのまま通す
+	// 別名記法のみを処理する
+
+	// まず、不正な別名記法（小文字を含む、存在しないパラメータ）をチェック
+	invalidPattern := regexp.MustCompile(`\{\{([A-Za-z_]+)\}\}`)
+	matches := invalidPattern.FindAllStringSubmatch(template, -1)
+
+	for _, match := range matches {
+		// 完全な別名記法の部分
+		fullMatch := match[0]
+		// 中身の部分（{{と}}を除いた部分）
+		innerContent := match[1]
+
+		// ドットで始まる場合は既存記法なのでスキップ
+		if strings.HasPrefix(fullMatch, "{{.") {
+			continue
+		}
+
+		// if、end、elseなどのテンプレート制御構文はスキップ
+		if isTemplateControl(innerContent) {
+			continue
+		}
+
+		// 大文字とアンダースコアのみで構成されているかチェック
+		if !isUpperCaseOnly(innerContent) {
+			// 小文字が含まれている場合はエラー
+			suggestion := strings.ToUpper(innerContent)
+			if _, exists := c.aliasMap[suggestion]; exists {
+				return "", &TemplateAliasError{
+					InvalidAlias: fullMatch,
+					Message:      fmt.Sprintf("別名記法では大文字のみが許可されています。'%s' の代わりに '{{%s}}' を使用してください", fullMatch, suggestion),
+				}
+			}
+			return "", &TemplateAliasError{
+				InvalidAlias: fullMatch,
+				Message:      fmt.Sprintf("別名記法では大文字のみが許可されています: '%s'", fullMatch),
+			}
+		}
+
+		// 存在するパラメータかチェック
+		if _, exists := c.aliasMap[innerContent]; !exists {
+			// 存在しないパラメータの場合はエラー
+			validAliases := c.getValidAliases()
+			return "", &TemplateAliasError{
+				InvalidAlias: fullMatch,
+				Message:      fmt.Sprintf("存在しないパラメータです: '%s'。使用可能なパラメータ: %s", fullMatch, strings.Join(validAliases, ", ")),
+			}
+		}
+	}
+
+	// エラーチェックが通ったら、別名を既存記法に変換
+	result := template
+	for alias, replacement := range c.aliasMap {
+		pattern := fmt.Sprintf("{{%s}}", alias)
+		newPattern := fmt.Sprintf("{{%s}}", replacement)
+		result = strings.ReplaceAll(result, pattern, newPattern)
+	}
+
+	return result, nil
+}
+
+// isUpperCaseOnly は文字列が大文字とアンダースコアのみで構成されているかチェック
+func isUpperCaseOnly(s string) bool {
+	for _, r := range s {
+		if r != '_' && (r < 'A' || r > 'Z') {
+			return false
+		}
+	}
+	return true
+}
+
+// isTemplateControl はテンプレート制御構文かどうかチェック
+func isTemplateControl(s string) bool {
+	// テンプレート制御構文のキーワード
+	controls := []string{"if", "else", "end", "range", "with", "define", "template", "block"}
+
+	// 先頭の単語を取得
+	parts := strings.Fields(s)
+	if len(parts) == 0 {
+		return false
+	}
+
+	firstWord := strings.ToLower(parts[0])
+	for _, control := range controls {
+		if firstWord == control {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getValidAliases は使用可能な別名のリストを返す
+func (c *TemplateAliasConverter) getValidAliases() []string {
+	aliases := make([]string, 0, len(c.aliasMap))
+	for alias := range c.aliasMap {
+		aliases = append(aliases, "{{"+alias+"}}")
+	}
+	return aliases
+}
+

--- a/internal/domain/entity/template_alias_test.go
+++ b/internal/domain/entity/template_alias_test.go
@@ -1,0 +1,325 @@
+package entity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPromptTemplateAliasConverter(t *testing.T) {
+	converter := NewPromptTemplateAliasConverter()
+	assert.NotNil(t, converter)
+	assert.NotNil(t, converter.aliasMap)
+	assert.Equal(t, 3, len(converter.aliasMap))
+	assert.Equal(t, ".Title", converter.aliasMap["TITLE"])
+	assert.Equal(t, ".Link", converter.aliasMap["URL"])
+	assert.Equal(t, ".Content", converter.aliasMap["CONTENT"])
+}
+
+func TestNewSlackTemplateAliasConverter(t *testing.T) {
+	converter := NewSlackTemplateAliasConverter()
+	assert.NotNil(t, converter)
+	assert.NotNil(t, converter.aliasMap)
+	assert.Equal(t, 5, len(converter.aliasMap))
+	assert.Equal(t, ".Article.Title", converter.aliasMap["TITLE"])
+	assert.Equal(t, ".Article.Link", converter.aliasMap["URL"])
+	assert.Equal(t, ".Article.Content", converter.aliasMap["CONTENT"])
+	assert.Equal(t, ".Comment", converter.aliasMap["COMMENT"])
+	assert.Equal(t, ".FixedMessage", converter.aliasMap["FIXED_MESSAGE"])
+}
+
+func TestPromptTemplateAliasConverter_Convert(t *testing.T) {
+	converter := NewPromptTemplateAliasConverter()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		// 正常系テスト
+		{
+			name:        "単一の別名記法",
+			input:       "記事タイトル: {{TITLE}}",
+			expected:    "記事タイトル: {{.Title}}",
+			expectError: false,
+		},
+		{
+			name:        "複数の別名記法",
+			input:       "{{TITLE}} - {{URL}} - {{CONTENT}}",
+			expected:    "{{.Title}} - {{.Link}} - {{.Content}}",
+			expectError: false,
+		},
+		{
+			name:        "新旧記法の混在",
+			input:       "{{TITLE}} - {{.Link}} - {{CONTENT}}",
+			expected:    "{{.Title}} - {{.Link}} - {{.Content}}",
+			expectError: false,
+		},
+		{
+			name:        "既存記法のみ",
+			input:       "{{.Title}} - {{.Link}} - {{.Content}}",
+			expected:    "{{.Title}} - {{.Link}} - {{.Content}}",
+			expectError: false,
+		},
+		{
+			name:        "テンプレート制御構文との共存",
+			input:       "{{if .Title}}{{TITLE}}{{else}}No title{{end}}",
+			expected:    "{{if .Title}}{{.Title}}{{else}}No title{{end}}",
+			expectError: false,
+		},
+		{
+			name:        "アンダースコアを含む別名",
+			input:       "{{FIXED_MESSAGE}}",
+			expected:    "{{FIXED_MESSAGE}}",
+			expectError: true,
+			errorMsg:    "存在しないパラメータです: '{{FIXED_MESSAGE}}'",
+		},
+
+		// 異常系テスト
+		{
+			name:        "小文字の別名記法",
+			input:       "{{title}}",
+			expected:    "",
+			expectError: true,
+			errorMsg:    "別名記法では大文字のみが許可されています。'{{title}}' の代わりに '{{TITLE}}' を使用してください",
+		},
+		{
+			name:        "大文字小文字混在",
+			input:       "{{Title}}",
+			expected:    "",
+			expectError: true,
+			errorMsg:    "別名記法では大文字のみが許可されています。'{{Title}}' の代わりに '{{TITLE}}' を使用してください",
+		},
+		{
+			name:        "存在しないパラメータ",
+			input:       "{{INVALID}}",
+			expected:    "",
+			expectError: true,
+			errorMsg:    "存在しないパラメータです: '{{INVALID}}'",
+		},
+		{
+			name:        "ドット記法混在エラー",
+			input:       "{{.TITLE}}",
+			expected:    "{{.TITLE}}",
+			expectError: false, // 既存記法として扱われるためエラーにならない
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := converter.Convert(tt.input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if aliasErr, ok := err.(*TemplateAliasError); ok {
+					assert.Contains(t, aliasErr.Message, tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestSlackTemplateAliasConverter_Convert(t *testing.T) {
+	converter := NewSlackTemplateAliasConverter()
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+		errorMsg    string
+	}{
+		// 正常系テスト
+		{
+			name:        "Slack用の全別名記法",
+			input:       "{{TITLE}} {{URL}} {{CONTENT}} {{COMMENT}} {{FIXED_MESSAGE}}",
+			expected:    "{{.Article.Title}} {{.Article.Link}} {{.Article.Content}} {{.Comment}} {{.FixedMessage}}",
+			expectError: false,
+		},
+		{
+			name:        "新旧記法の混在",
+			input:       "{{TITLE}} - {{.Article.Link}} - {{COMMENT}}",
+			expected:    "{{.Article.Title}} - {{.Article.Link}} - {{.Comment}}",
+			expectError: false,
+		},
+		{
+			name:        "条件分岐との組み合わせ",
+			input:       "{{if .Comment}}{{COMMENT}}{{end}}{{TITLE}}",
+			expected:    "{{if .Comment}}{{.Comment}}{{end}}{{.Article.Title}}",
+			expectError: false,
+		},
+
+		// 異常系テスト
+		{
+			name:        "小文字の別名記法",
+			input:       "{{comment}}",
+			expected:    "",
+			expectError: true,
+			errorMsg:    "別名記法では大文字のみが許可されています。'{{comment}}' の代わりに '{{COMMENT}}' を使用してください",
+		},
+		{
+			name:        "存在しないパラメータ",
+			input:       "{{AUTHOR}}",
+			expected:    "",
+			expectError: true,
+			errorMsg:    "存在しないパラメータです: '{{AUTHOR}}'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := converter.Convert(tt.input)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				if aliasErr, ok := err.(*TemplateAliasError); ok {
+					assert.Contains(t, aliasErr.Message, tt.errorMsg)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsUpperCaseOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "大文字のみ",
+			input:    "TITLE",
+			expected: true,
+		},
+		{
+			name:     "アンダースコア付き",
+			input:    "FIXED_MESSAGE",
+			expected: true,
+		},
+		{
+			name:     "小文字混在",
+			input:    "Title",
+			expected: false,
+		},
+		{
+			name:     "全て小文字",
+			input:    "title",
+			expected: false,
+		},
+		{
+			name:     "数字を含む",
+			input:    "TITLE123",
+			expected: false,
+		},
+		{
+			name:     "空文字列",
+			input:    "",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isUpperCaseOnly(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIsTemplateControl(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{
+			name:     "if文",
+			input:    "if .Comment",
+			expected: true,
+		},
+		{
+			name:     "else文",
+			input:    "else",
+			expected: true,
+		},
+		{
+			name:     "end文",
+			input:    "end",
+			expected: true,
+		},
+		{
+			name:     "range文",
+			input:    "range .Items",
+			expected: true,
+		},
+		{
+			name:     "非制御構文",
+			input:    "TITLE",
+			expected: false,
+		},
+		{
+			name:     "大文字のIF",
+			input:    "IF .Comment",
+			expected: true, // 大文字小文字を区別しない
+		},
+		{
+			name:     "空文字列",
+			input:    "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isTemplateControl(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTemplateAliasError(t *testing.T) {
+	err := &TemplateAliasError{
+		InvalidAlias: "{{title}}",
+		Message:      "別名記法では大文字のみが許可されています",
+	}
+
+	assert.Equal(t, "別名記法では大文字のみが許可されています", err.Error())
+	assert.Equal(t, "{{title}}", err.InvalidAlias)
+}
+
+func TestGetValidAliases(t *testing.T) {
+	t.Run("PromptConverter", func(t *testing.T) {
+		converter := NewPromptTemplateAliasConverter()
+		aliases := converter.getValidAliases()
+
+		assert.Equal(t, 3, len(aliases))
+		// マップの順序は保証されないので、要素の存在だけ確認
+		aliasesStr := strings.Join(aliases, " ")
+		assert.Contains(t, aliasesStr, "{{TITLE}}")
+		assert.Contains(t, aliasesStr, "{{URL}}")
+		assert.Contains(t, aliasesStr, "{{CONTENT}}")
+	})
+
+	t.Run("SlackConverter", func(t *testing.T) {
+		converter := NewSlackTemplateAliasConverter()
+		aliases := converter.getValidAliases()
+
+		assert.Equal(t, 5, len(aliases))
+		aliasesStr := strings.Join(aliases, " ")
+		assert.Contains(t, aliasesStr, "{{TITLE}}")
+		assert.Contains(t, aliasesStr, "{{URL}}")
+		assert.Contains(t, aliasesStr, "{{CONTENT}}")
+		assert.Contains(t, aliasesStr, "{{COMMENT}}")
+		assert.Contains(t, aliasesStr, "{{FIXED_MESSAGE}}")
+	})
+}
+

--- a/internal/domain/entity/template_alias_test.go
+++ b/internal/domain/entity/template_alias_test.go
@@ -322,4 +322,3 @@ func TestGetValidAliases(t *testing.T) {
 		assert.Contains(t, aliasesStr, "{{FIXED_MESSAGE}}")
 	})
 }
-

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -232,10 +232,27 @@ func (c *SlackAPIConfig) ToEntity() (*entity.SlackAPIConfig, error) {
 		return nil, err
 	}
 
+	// MessageTemplateの別名変換処理
+	var convertedTemplate *string
+	if c.MessageTemplate != nil && *c.MessageTemplate != "" {
+		converter := entity.NewSlackTemplateAliasConverter()
+		converted, err := converter.Convert(*c.MessageTemplate)
+		if err != nil {
+			// 別名変換エラーの場合は、エラーを返す
+			if aliasErr, ok := err.(*entity.TemplateAliasError); ok {
+				return nil, fmt.Errorf("テンプレートエラー: %s", aliasErr.Message)
+			}
+			return nil, err
+		}
+		convertedTemplate = &converted
+	} else {
+		convertedTemplate = c.MessageTemplate
+	}
+
 	return &entity.SlackAPIConfig{
 		APIToken:        apiToken,
 		Channel:         c.Channel,
-		MessageTemplate: c.MessageTemplate,
+		MessageTemplate: convertedTemplate,
 	}, nil
 }
 

--- a/internal/infra/message/builder.go
+++ b/internal/infra/message/builder.go
@@ -15,7 +15,18 @@ type MessageBuilder struct {
 
 // NewMessageBuilder は新しいMessageBuilderを作成する
 func NewMessageBuilder(recommendTemplate string) (*MessageBuilder, error) {
-	tmpl, err := template.New("recommend").Parse(recommendTemplate)
+	// 別名記法を既存記法に変換
+	converter := entity.NewSlackTemplateAliasConverter()
+	convertedTemplate, err := converter.Convert(recommendTemplate)
+	if err != nil {
+		// 別名変換エラーの場合は、詳細なエラーメッセージを返す
+		if aliasErr, ok := err.(*entity.TemplateAliasError); ok {
+			return nil, fmt.Errorf("テンプレートエラー: %s", aliasErr.Message)
+		}
+		return nil, err
+	}
+
+	tmpl, err := template.New("recommend").Parse(convertedTemplate)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infra/message/builder_test.go
+++ b/internal/infra/message/builder_test.go
@@ -45,6 +45,58 @@ func TestNewMessageBuilder(t *testing.T) {
 	}
 }
 
+func TestNewMessageBuilder_WithAliases(t *testing.T) {
+	tests := []struct {
+		name          string
+		template      string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "別名記法を含むテンプレート",
+			template:    "Title: {{TITLE}}\nURL: {{URL}}",
+			expectError: false,
+		},
+		{
+			name:        "新旧記法の混在",
+			template:    "{{TITLE}} - {{.Article.Link}}",
+			expectError: false,
+		},
+		{
+			name:        "条件分岐と別名記法",
+			template:    "{{if .Comment}}{{COMMENT}}{{end}}{{TITLE}}",
+			expectError: false,
+		},
+		{
+			name:          "小文字の別名記法でエラー",
+			template:      "{{title}}",
+			expectError:   true,
+			errorContains: "別名記法では大文字のみが許可されています",
+		},
+		{
+			name:          "存在しない別名でエラー",
+			template:      "{{AUTHOR}}",
+			expectError:   true,
+			errorContains: "存在しないパラメータです",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, err := NewMessageBuilder(tt.template)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				assert.Nil(t, builder)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, builder)
+			}
+		})
+	}
+}
+
 func TestMessageBuilder_BuildRecommendMessage(t *testing.T) {
 	now := time.Now()
 	comment := "おすすめの記事です"
@@ -114,6 +166,89 @@ func TestMessageBuilder_BuildRecommendMessage(t *testing.T) {
 			fixedMessage: "テストメッセージ",
 			expected:     "",
 			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, err := NewMessageBuilder(tt.template)
+			require.NoError(t, err)
+
+			result, err := builder.BuildRecommendMessage(tt.recommend, tt.fixedMessage)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMessageBuilder_BuildRecommendMessage_WithAliases(t *testing.T) {
+	now := time.Now()
+	comment := "おすすめの記事です"
+
+	tests := []struct {
+		name         string
+		template     string
+		recommend    *entity.Recommend
+		fixedMessage string
+		expected     string
+		expectError  bool
+	}{
+		{
+			name:     "別名記法のみのテンプレート",
+			template: "{{TITLE}}\n{{URL}}\n{{if .Comment}}{{COMMENT}}{{end}}",
+			recommend: &entity.Recommend{
+				Article: entity.Article{
+					Title:     "テスト記事",
+					Link:      "https://example.com",
+					Published: &now,
+					Content:   "テスト内容",
+				},
+				Comment: &comment,
+			},
+			expected: "テスト記事\nhttps://example.com\nおすすめの記事です",
+		},
+		{
+			name:     "新旧記法の混在テンプレート",
+			template: "Title: {{TITLE}}\nURL: {{.Article.Link}}\n{{if .Comment}}Comment: {{COMMENT}}{{end}}",
+			recommend: &entity.Recommend{
+				Article: entity.Article{
+					Title:   "混在テスト",
+					Link:    "https://test.com",
+					Content: "内容",
+				},
+				Comment: &comment,
+			},
+			expected: "Title: 混在テスト\nURL: https://test.com\nComment: おすすめの記事です",
+		},
+		{
+			name:     "FIXED_MESSAGE別名の使用",
+			template: "{{TITLE}}\n{{if .FixedMessage}}{{FIXED_MESSAGE}}{{end}}",
+			recommend: &entity.Recommend{
+				Article: entity.Article{
+					Title: "固定メッセージテスト",
+				},
+			},
+			fixedMessage: "重要なお知らせ",
+			expected:     "固定メッセージテスト\n重要なお知らせ",
+		},
+		{
+			name:     "全別名記法の使用",
+			template: "{{TITLE}}\n{{URL}}\n{{CONTENT}}\n{{if .Comment}}{{COMMENT}}\n{{end}}{{if .FixedMessage}}{{FIXED_MESSAGE}}{{end}}",
+			recommend: &entity.Recommend{
+				Article: entity.Article{
+					Title:   "フルテスト",
+					Link:    "https://full.test",
+					Content: "完全なテスト内容",
+				},
+				Comment: &comment,
+			},
+			fixedMessage: "追加メッセージ",
+			expected:     "フルテスト\nhttps://full.test\n完全なテスト内容\nおすすめの記事です\n追加メッセージ",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- テンプレート記法の別名機能を実装
- `{{TITLE}}`、`{{URL}}`、`{{CONTENT}}`、`{{COMMENT}}`、`{{FIXED_MESSAGE}}`の別名記法をサポート
- 既存記法との完全な後方互換性を維持
- 包括的なテストケースとドキュメントを追加

## 実装内容

### 新機能
- **テンプレート別名変換**: 直感的な大文字記法をサポート
- **エラーハンドリング**: ユーザーフレンドリーなエラーメッセージ
- **新旧記法の混在**: 同一テンプレート内で併用可能

### 対象コンポーネント
- `PromptConfig.CommentPromptTemplate`
- `SlackAPIConfig.MessageTemplate`
- `MessageBuilder`

### 使用例
```yaml
# 新記法（推奨）
comment_prompt_template: |
  記事: {{TITLE}}
  URL: {{URL}}
  内容: {{CONTENT}}

# 既存記法（引き続き利用可能）
comment_prompt_template: |
  記事: {{.Title}}
  URL: {{.Link}}
  内容: {{.Content}}

# 混在も可能
message_template: |
  {{TITLE}} - {{.Article.Link}}
  {{if .Comment}}{{COMMENT}}{{end}}
```

## Test plan

- [x] 単体テスト: 正常系・異常系・境界値テストを実装
- [x] 統合テスト: 既存機能との互換性を確認
- [x] エラーハンドリング: 不正な記法のエラーメッセージを検証
- [x] 後方互換性: 既存の設定ファイルが引き続き動作することを確認
- [x] ビルド・リント: 全チェックが正常に完了

## 変更ファイル

- `README.md`: 使用例とドキュメントを追加
- `internal/domain/entity/template_alias.go`: 別名変換機能の実装
- `internal/domain/entity/template_alias_test.go`: 包括的なテストケース
- `internal/domain/entity/config.go`: PromptConfig統合
- `internal/infra/config.go`: SlackAPIConfig統合
- `internal/infra/message/builder.go`: MessageBuilder統合
- `internal/infra/message/builder_test.go`: 統合テスト追加

🤖 Generated with [Claude Code](https://claude.ai/code)