### PR TITLE
ハードコーディングしてるデフォルトテンプレートを削除

### DIFF
--- a/cmd/runner/recommend_test.go
+++ b/cmd/runner/recommend_test.go
@@ -49,8 +49,9 @@ func TestNewRecommendRunner(t *testing.T) {
 			name: "Successful creation with SlackAPI viewer",
 			outputConfig: &infra.OutputConfig{
 				SlackAPI: &infra.SlackAPIConfig{
-					APIToken: "test-token",
-					Channel:  "#test",
+					APIToken:        "test-token",
+					Channel:         "#test",
+					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			promptConfig: &infra.PromptConfig{CommentPromptTemplate: "test-template"},
@@ -60,8 +61,9 @@ func TestNewRecommendRunner(t *testing.T) {
 			name: "Successful creation with Misskey viewer",
 			outputConfig: &infra.OutputConfig{
 				Misskey: &infra.MisskeyConfig{
-					APIToken: "test-token",
-					APIURL:   "https://test.misskey.io/api",
+					APIToken:        "test-token",
+					APIURL:          "https://test.misskey.io/api",
+					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			promptConfig: &infra.PromptConfig{CommentPromptTemplate: "test-template"},

--- a/cmd/runner/test_helpers.go
+++ b/cmd/runner/test_helpers.go
@@ -1,0 +1,6 @@
+package runner
+
+// stringPtr はテスト用にstring値のポインタを返すヘルパー関数
+func stringPtr(s string) *string {
+	return &s
+}

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -142,8 +142,10 @@ func (m *MisskeyConfig) Validate() *ValidationResult {
 		builder.AddError(err.Error())
 	}
 
-	// MessageTemplate: 存在する場合はtext/templateとして妥当であること
-	if m.MessageTemplate != nil {
+	// MessageTemplate: 必須項目
+	if m.MessageTemplate == nil || strings.TrimSpace(*m.MessageTemplate) == "" {
+		builder.AddError("Misskeyメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nmisskey:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}")
+	} else {
 		if err := m.validateMisskeyMessageTemplate(*m.MessageTemplate); err != nil {
 			builder.AddError(fmt.Sprintf("Misskeyメッセージテンプレートが無効です: %v", err))
 		}
@@ -154,11 +156,6 @@ func (m *MisskeyConfig) Validate() *ValidationResult {
 
 // validateMisskeyMessageTemplate はMisskeyメッセージテンプレートの構文を検証する
 func (m *MisskeyConfig) validateMisskeyMessageTemplate(templateStr string) error {
-	// 空文字列や空白のみの場合はエラーとしない（デフォルトテンプレートが使用される）
-	if strings.TrimSpace(templateStr) == "" {
-		return nil
-	}
-
 	// text/templateでパースして構文チェック
 	_, err := template.New("misskey_message").Parse(templateStr)
 	if err != nil {
@@ -188,8 +185,10 @@ func (s *SlackAPIConfig) Validate() *ValidationResult {
 		builder.AddError(err.Error())
 	}
 
-	// MessageTemplate: 存在する場合はtext/templateとして妥当であること
-	if s.MessageTemplate != nil {
+	// MessageTemplate: 必須項目
+	if s.MessageTemplate == nil || strings.TrimSpace(*s.MessageTemplate) == "" {
+		builder.AddError("Slackメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nslack_api:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}")
+	} else {
 		if err := s.validateSlackMessageTemplate(*s.MessageTemplate); err != nil {
 			builder.AddError(fmt.Sprintf("Slackメッセージテンプレートが無効です: %v", err))
 		}
@@ -200,11 +199,6 @@ func (s *SlackAPIConfig) Validate() *ValidationResult {
 
 // validateSlackMessageTemplate はSlackメッセージテンプレートの構文を検証する
 func (s *SlackAPIConfig) validateSlackMessageTemplate(templateStr string) error {
-	// 空文字列や空白のみの場合はエラーとしない（デフォルトテンプレートが使用される）
-	if strings.TrimSpace(templateStr) == "" {
-		return nil
-	}
-
 	// text/templateでパースして構文チェック
 	_, err := template.New("slack_message").Parse(templateStr)
 	if err != nil {

--- a/internal/domain/entity/config_test.go
+++ b/internal/domain/entity/config_test.go
@@ -118,10 +118,11 @@ func TestMisskeyConfig_Validate(t *testing.T) {
 		errors  []string
 	}{
 		{
-			name: "正常系_必須項目のみ",
+			name: "正常系_必須項目すべて",
 			config: &MisskeyConfig{
-				APIToken: "valid-token",
-				APIURL:   "https://misskey.example.com",
+				APIToken:        "valid-token",
+				APIURL:          "https://misskey.example.com",
+				MessageTemplate: &validTemplate,
 			},
 			wantErr: false,
 		},
@@ -135,19 +136,30 @@ func TestMisskeyConfig_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "正常系_空のテンプレート",
+			name: "異常系_MessageTemplateが未設定",
+			config: &MisskeyConfig{
+				APIToken: "valid-token",
+				APIURL:   "https://misskey.example.com",
+			},
+			wantErr: true,
+			errors:  []string{"Misskeyメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nmisskey:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}"},
+		},
+		{
+			name: "異常系_MessageTemplateが空文字列",
 			config: &MisskeyConfig{
 				APIToken:        "valid-token",
 				APIURL:          "https://misskey.example.com",
 				MessageTemplate: &emptyTemplate,
 			},
-			wantErr: false,
+			wantErr: true,
+			errors:  []string{"Misskeyメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nmisskey:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}"},
 		},
 		{
 			name: "異常系_APITokenが空",
 			config: &MisskeyConfig{
-				APIToken: "",
-				APIURL:   "https://misskey.example.com",
+				APIToken:        "",
+				APIURL:          "https://misskey.example.com",
+				MessageTemplate: &validTemplate,
 			},
 			wantErr: true,
 			errors:  []string{"Misskey APIトークンが設定されていません"},
@@ -155,8 +167,9 @@ func TestMisskeyConfig_Validate(t *testing.T) {
 		{
 			name: "異常系_APIURLが空",
 			config: &MisskeyConfig{
-				APIToken: "valid-token",
-				APIURL:   "",
+				APIToken:        "valid-token",
+				APIURL:          "",
+				MessageTemplate: &validTemplate,
 			},
 			wantErr: true,
 			errors:  []string{"Misskey API URLが設定されていません"},
@@ -164,8 +177,9 @@ func TestMisskeyConfig_Validate(t *testing.T) {
 		{
 			name: "異常系_APIURLが不正なURL",
 			config: &MisskeyConfig{
-				APIToken: "valid-token",
-				APIURL:   "not-a-url",
+				APIToken:        "valid-token",
+				APIURL:          "not-a-url",
+				MessageTemplate: &validTemplate,
 			},
 			wantErr: true,
 			errors:  []string{"Misskey API URLが正しいURL形式ではありません"},
@@ -183,15 +197,14 @@ func TestMisskeyConfig_Validate(t *testing.T) {
 		{
 			name: "異常系_複数のエラー",
 			config: &MisskeyConfig{
-				APIToken:        "",
-				APIURL:          "not-a-url",
-				MessageTemplate: &invalidTemplate,
+				APIToken: "",
+				APIURL:   "not-a-url",
 			},
 			wantErr: true,
 			errors: []string{
 				"Misskey APIトークンが設定されていません",
 				"Misskey API URLが正しいURL形式ではありません",
-				"Misskeyメッセージテンプレートが無効です: テンプレート構文エラー: template: misskey_message:1: unclosed action",
+				"Misskeyメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nmisskey:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}",
 			},
 		},
 	}

--- a/internal/domain/entity/config_test.go
+++ b/internal/domain/entity/config_test.go
@@ -66,10 +66,12 @@ func TestProfile_Validate(t *testing.T) {
 		SystemPrompt:          "システムプロンプト",
 		CommentPromptTemplate: "コメントテンプレート",
 	}
+	validTemplate := "{{.Article.Title}} {{.Article.Link}}"
 	validOutput := &OutputConfig{
 		SlackAPI: &SlackAPIConfig{
-			APIToken: "valid-token",
-			Channel:  "#general",
+			APIToken:        "valid-token",
+			Channel:         "#general",
+			MessageTemplate: &validTemplate,
 		},
 	}
 

--- a/internal/domain/entity/slack_config_test.go
+++ b/internal/domain/entity/slack_config_test.go
@@ -1,0 +1,106 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSlackAPIConfig_Validate はSlackAPIConfigのValidateメソッドをテストする
+func TestSlackAPIConfig_Validate(t *testing.T) {
+	validTemplate := "{{.Article.Title}} {{.Article.Link}}"
+	invalidTemplate := "{{.Article.Title" // 不正な構文
+	emptyTemplate := ""
+
+	tests := []struct {
+		name    string
+		config  *SlackAPIConfig
+		wantErr bool
+		errors  []string
+	}{
+		{
+			name: "正常系_必須項目すべて",
+			config: &SlackAPIConfig{
+				APIToken:        "xoxb-valid-token",
+				Channel:         "#test",
+				MessageTemplate: &validTemplate,
+			},
+			wantErr: false,
+		},
+		{
+			name: "異常系_MessageTemplateが未設定",
+			config: &SlackAPIConfig{
+				APIToken: "xoxb-valid-token",
+				Channel:  "#test",
+			},
+			wantErr: true,
+			errors:  []string{"Slackメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nslack_api:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}"},
+		},
+		{
+			name: "異常系_MessageTemplateが空文字列",
+			config: &SlackAPIConfig{
+				APIToken:        "xoxb-valid-token",
+				Channel:         "#test",
+				MessageTemplate: &emptyTemplate,
+			},
+			wantErr: true,
+			errors:  []string{"Slackメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nslack_api:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}"},
+		},
+		{
+			name: "異常系_APITokenが空",
+			config: &SlackAPIConfig{
+				APIToken:        "",
+				Channel:         "#test",
+				MessageTemplate: &validTemplate,
+			},
+			wantErr: true,
+			errors:  []string{"Slack APIトークンが設定されていません"},
+		},
+		{
+			name: "異常系_Channelが空",
+			config: &SlackAPIConfig{
+				APIToken:        "xoxb-valid-token",
+				Channel:         "",
+				MessageTemplate: &validTemplate,
+			},
+			wantErr: true,
+			errors:  []string{"Slackチャンネルが設定されていません"},
+		},
+		{
+			name: "異常系_不正なテンプレート構文",
+			config: &SlackAPIConfig{
+				APIToken:        "xoxb-valid-token",
+				Channel:         "#test",
+				MessageTemplate: &invalidTemplate,
+			},
+			wantErr: true,
+			errors:  []string{"Slackメッセージテンプレートが無効です: テンプレート構文エラー: template: slack_message:1: unclosed action"},
+		},
+		{
+			name: "異常系_複数のエラー",
+			config: &SlackAPIConfig{
+				APIToken: "",
+				Channel:  "",
+			},
+			wantErr: true,
+			errors: []string{
+				"Slack APIトークンが設定されていません",
+				"Slackチャンネルが設定されていません",
+				"Slackメッセージテンプレートが設定されていません。config.yml または profile.yml で message_template を設定してください。\n設定例:\nslack_api:\n  message_template: |\n    {{if .Comment}}{{.Comment}}\n    {{end}}{{.Article.Title}}\n    {{.Article.Link}}",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.config.Validate()
+
+			assert.Equal(t, !tt.wantErr, result.IsValid)
+			if tt.wantErr {
+				assert.Equal(t, tt.errors, result.Errors)
+			} else {
+				assert.Empty(t, result.Errors)
+			}
+		})
+	}
+}

--- a/internal/infra/message/misskey.go
+++ b/internal/infra/message/misskey.go
@@ -45,6 +45,10 @@ func NewMisskeySender(instanceURL, accessToken string, messageTemplate *string) 
 	}
 
 	// 設定読み込み時にテンプレートは検証済みのため、template.Mustが安全に使用できる
+	// ただし、テストやバリデーション前の呼び出しに対応するため念のためnilチェックを行う
+	if messageTemplate == nil || *messageTemplate == "" {
+		return nil, fmt.Errorf("MessageTemplate is required and must be validated before creating MisskeySender")
+	}
 	tmpl := template.Must(template.New("misskey_message").Parse(*messageTemplate))
 
 	return &MisskeySender{

--- a/internal/infra/message/misskey.go
+++ b/internal/infra/message/misskey.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 	"text/template"
 
 	"github.com/canpok1/ai-feed/internal/domain"
@@ -21,12 +20,6 @@ type MisskeyTemplateData struct {
 	Comment      *string
 	FixedMessage string
 }
-
-// DefaultMisskeyMessageTemplate はデフォルトのMisskeyメッセージテンプレート
-const DefaultMisskeyMessageTemplate = `{{if .Comment}}{{.Comment}}
-{{end}}{{.Article.Title}}
-{{.Article.Link}}{{if .FixedMessage}}
-{{.FixedMessage}}{{end}}`
 
 // MisskeySender はMisskey APIと通信するためのクライアントです。
 
@@ -51,16 +44,8 @@ func NewMisskeySender(instanceURL, accessToken string, messageTemplate *string) 
 		return nil, fmt.Errorf("failed to create Misskey client: %w", err)
 	}
 
-	// テンプレートの設定
-	var templateStr string
-	if messageTemplate != nil && strings.TrimSpace(*messageTemplate) != "" {
-		templateStr = *messageTemplate
-	} else {
-		templateStr = DefaultMisskeyMessageTemplate
-	}
-
 	// 設定読み込み時にテンプレートは検証済みのため、template.Mustが安全に使用できる
-	tmpl := template.Must(template.New("misskey_message").Parse(templateStr))
+	tmpl := template.Must(template.New("misskey_message").Parse(*messageTemplate))
 
 	return &MisskeySender{
 		client: client,

--- a/internal/infra/message/misskey_test.go
+++ b/internal/infra/message/misskey_test.go
@@ -22,30 +22,6 @@ func TestNewMisskeySender(t *testing.T) {
 		expectError      bool
 	}{
 		{
-			name:             "デフォルトテンプレート（MessageTemplateがnil）",
-			instanceURL:      "https://misskey.example.com",
-			accessToken:      "test-token",
-			messageTemplate:  nil,
-			expectedTemplate: DefaultMisskeyMessageTemplate,
-			expectError:      false,
-		},
-		{
-			name:             "デフォルトテンプレート（MessageTemplateが空文字列）",
-			instanceURL:      "https://misskey.example.com",
-			accessToken:      "test-token",
-			messageTemplate:  stringPtr(""),
-			expectedTemplate: DefaultMisskeyMessageTemplate,
-			expectError:      false,
-		},
-		{
-			name:             "デフォルトテンプレート（MessageTemplateが空白のみ）",
-			instanceURL:      "https://misskey.example.com",
-			accessToken:      "test-token",
-			messageTemplate:  stringPtr("   \n\t  "),
-			expectedTemplate: DefaultMisskeyMessageTemplate,
-			expectError:      false,
-		},
-		{
 			name:             "カスタムテンプレート",
 			instanceURL:      "https://misskey.example.com",
 			accessToken:      "test-token",
@@ -111,7 +87,7 @@ func TestMisskeyTemplateExecution(t *testing.T) {
 	}{
 		{
 			name:            "デフォルトテンプレート（全フィールドあり）",
-			messageTemplate: DefaultMisskeyMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &MisskeyTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",
@@ -127,7 +103,7 @@ func TestMisskeyTemplateExecution(t *testing.T) {
 		},
 		{
 			name:            "デフォルトテンプレート（コメントなし）",
-			messageTemplate: DefaultMisskeyMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &MisskeyTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",
@@ -143,7 +119,7 @@ func TestMisskeyTemplateExecution(t *testing.T) {
 		},
 		{
 			name:            "デフォルトテンプレート（固定メッセージなし）",
-			messageTemplate: DefaultMisskeyMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &MisskeyTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",
@@ -159,7 +135,7 @@ func TestMisskeyTemplateExecution(t *testing.T) {
 		},
 		{
 			name:            "デフォルトテンプレート（コメントと固定メッセージなし）",
-			messageTemplate: DefaultMisskeyMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &MisskeyTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",

--- a/internal/infra/message/slack.go
+++ b/internal/infra/message/slack.go
@@ -2,18 +2,12 @@ package message
 
 import (
 	"bytes"
-	"strings"
 	"text/template"
 
 	"github.com/canpok1/ai-feed/internal/domain"
 	"github.com/canpok1/ai-feed/internal/domain/entity"
 	"github.com/slack-go/slack"
 )
-
-const DefaultSlackMessageTemplate = `{{if .Comment}}{{.Comment}}
-{{end}}{{.Article.Title}}
-{{.Article.Link}}{{if .FixedMessage}}
-{{.FixedMessage}}{{end}}`
 
 type SlackTemplateData struct {
 	Article      *entity.Article
@@ -28,14 +22,8 @@ type SlackSender struct {
 }
 
 func NewSlackSender(config *entity.SlackAPIConfig) domain.MessageSender {
-	// メッセージテンプレートの設定
-	messageTemplate := DefaultSlackMessageTemplate
-	if config.MessageTemplate != nil && strings.TrimSpace(*config.MessageTemplate) != "" {
-		messageTemplate = *config.MessageTemplate
-	}
-
 	// 設定読み込み時にテンプレートは検証済みのため、template.Mustが安全に使用できる
-	tmpl := template.Must(template.New("slack_message").Parse(messageTemplate))
+	tmpl := template.Must(template.New("slack_message").Parse(*config.MessageTemplate))
 
 	return &SlackSender{
 		client:    slack.New(config.APIToken),

--- a/internal/infra/message/slack.go
+++ b/internal/infra/message/slack.go
@@ -23,6 +23,10 @@ type SlackSender struct {
 
 func NewSlackSender(config *entity.SlackAPIConfig) domain.MessageSender {
 	// 設定読み込み時にテンプレートは検証済みのため、template.Mustが安全に使用できる
+	// ただし、テストやバリデーション前の呼び出しに対応するため念のためnilチェックを行う
+	if config.MessageTemplate == nil || *config.MessageTemplate == "" {
+		panic("MessageTemplate is required and must be validated before creating SlackSender")
+	}
 	tmpl := template.Must(template.New("slack_message").Parse(*config.MessageTemplate))
 
 	return &SlackSender{

--- a/internal/infra/message/slack_test.go
+++ b/internal/infra/message/slack_test.go
@@ -19,33 +19,6 @@ func TestNewSlackSender(t *testing.T) {
 		expectedTemplate string
 	}{
 		{
-			name: "デフォルトテンプレート（MessageTemplateがnil）",
-			config: &entity.SlackAPIConfig{
-				APIToken:        "xoxb-test-token",
-				Channel:         "#test",
-				MessageTemplate: nil,
-			},
-			expectedTemplate: DefaultSlackMessageTemplate,
-		},
-		{
-			name: "デフォルトテンプレート（MessageTemplateが空文字列）",
-			config: &entity.SlackAPIConfig{
-				APIToken:        "xoxb-test-token",
-				Channel:         "#test",
-				MessageTemplate: stringPtr(""),
-			},
-			expectedTemplate: DefaultSlackMessageTemplate,
-		},
-		{
-			name: "デフォルトテンプレート（MessageTemplateが空白のみ）",
-			config: &entity.SlackAPIConfig{
-				APIToken:        "xoxb-test-token",
-				Channel:         "#test",
-				MessageTemplate: stringPtr("   \n\t  "),
-			},
-			expectedTemplate: DefaultSlackMessageTemplate,
-		},
-		{
 			name: "カスタムテンプレート",
 			config: &entity.SlackAPIConfig{
 				APIToken:        "xoxb-test-token",
@@ -98,7 +71,7 @@ func TestSlackTemplateExecution(t *testing.T) {
 	}{
 		{
 			name:            "デフォルトテンプレート（全フィールドあり）",
-			messageTemplate: DefaultSlackMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &SlackTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",
@@ -114,7 +87,7 @@ func TestSlackTemplateExecution(t *testing.T) {
 		},
 		{
 			name:            "デフォルトテンプレート（コメントなし）",
-			messageTemplate: DefaultSlackMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &SlackTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",
@@ -130,7 +103,7 @@ func TestSlackTemplateExecution(t *testing.T) {
 		},
 		{
 			name:            "デフォルトテンプレート（固定メッセージなし）",
-			messageTemplate: DefaultSlackMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &SlackTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",
@@ -146,7 +119,7 @@ func TestSlackTemplateExecution(t *testing.T) {
 		},
 		{
 			name:            "デフォルトテンプレート（コメントと固定メッセージなし）",
-			messageTemplate: DefaultSlackMessageTemplate,
+			messageTemplate: "{{if .Comment}}{{.Comment}}\n{{end}}{{.Article.Title}}\n{{.Article.Link}}{{if .FixedMessage}}\n{{.FixedMessage}}{{end}}",
 			templateData: &SlackTemplateData{
 				Article: &entity.Article{
 					Title:     "テスト記事",

--- a/internal/infra/templates/config.yml
+++ b/internal/infra/templates/config.yml
@@ -36,7 +36,7 @@ default_profile:
       # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
       channel: "#general"                     # 投稿先チャンネル
       
-      # Slackメッセージテンプレート（オプション）
+      # Slackメッセージテンプレート（必須）
       # 利用可能なパラメータ:
       #   {{.Comment}}         - AIが生成したコメント（存在する場合のみ）
       #   {{.Article.Title}}   - 記事のタイトル
@@ -58,3 +58,19 @@ default_profile:
       # api_token_env: MISSKEY_TOKEN          # 環境変数からトークンを取得する場合
       # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
       api_url: https://example.com            # MisskeyのAPIエンドポイント
+      
+      # Misskeyメッセージテンプレート（必須）
+      # 利用可能なパラメータ:
+      #   {{.Comment}}         - AIが生成したコメント（存在する場合のみ）
+      #   {{.Article.Title}}   - 記事のタイトル
+      #   {{.Article.Link}}    - 記事のURL
+      #   {{.Article.Content}} - 記事の本文内容
+      #   {{.FixedMessage}}    - 固定メッセージ（設定されている場合のみ）
+      # 条件分岐:
+      #   {{if .Comment}}...{{end}}      - コメントが存在する場合のみ表示
+      #   {{if .FixedMessage}}...{{end}} - 固定メッセージが存在する場合のみ表示
+      message_template: |
+        {{if .Comment}}{{.Comment}}
+        {{end}}{{.Article.Title}}
+        {{.Article.Link}}{{if .FixedMessage}}
+        {{.FixedMessage}}{{end}}

--- a/internal/infra/templates/profile.yml
+++ b/internal/infra/templates/profile.yml
@@ -36,7 +36,7 @@ output:
     # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
     channel: "#general"                     # 投稿先チャンネル
     
-    # Slackメッセージテンプレート（オプション）
+    # Slackメッセージテンプレート（必須）
     # 利用可能なパラメータ:
     #   {{.Comment}}         - AIが生成したコメント（存在する場合のみ）
     #   {{.Article.Title}}   - 記事のタイトル
@@ -59,7 +59,7 @@ output:
     # 注意: api_tokenとapi_token_envの両方が指定された場合、api_tokenが優先されます
     api_url: https://example.com            # MisskeyのAPIエンドポイント
     
-    # Misskeyノートテンプレート（オプション）
+    # Misskeyメッセージテンプレート（必須）
     # 利用可能なパラメータ:
     #   {{.Comment}}         - AIが生成したコメント（存在する場合のみ）
     #   {{.Article.Title}}   - 記事のタイトル


### PR DESCRIPTION
## Summary
- SlackとMisskeyのハードコーディングされたデフォルトメッセージテンプレートを削除
- テンプレート未設定時は適切なエラーメッセージを表示
- 設定テンプレートでmessage_templateを必須項目として明記

## Test plan
- [x] `make test` - 全テスト通過
- [x] `make lint` - リント通過  
- [x] `make build` - ビルド成功
- [x] テンプレート未設定時のエラーメッセージ確認
- [x] テンプレート設定時の正常動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)

fixed #103