### PR TITLE
エラー時にコマンドの使い方が表示されないようにする

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -26,5 +26,6 @@ func makeInitCmd() *cobra.Command {
 			return nil
 		},
 	}
+	cmd.SilenceUsage = true
 	return cmd
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -14,6 +14,7 @@ func makeProfileCmd() *cobra.Command {
 		Use:   "profile",
 		Short: "Manage user profiles.",
 	}
+	cmd.SilenceUsage = true
 	profileInitCmd := makeProfileInitCmd()
 	profileCheckCmd := makeProfileCheckCmd()
 	cmd.AddCommand(profileInitCmd)
@@ -26,29 +27,28 @@ func makeProfileInitCmd() *cobra.Command {
 		Use:   "init [file path]",
 		Short: "Initialize a new profile file.",
 		Args:  cobra.ExactArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			filePath := args[0]
 
 			// Check if file already exists to avoid accidental overwrites.
 			if _, err := os.Stat(filePath); !os.IsNotExist(err) {
 				if err == nil {
-					cmd.PrintErrf("Error: file already exists at %s. Please specify a new file path.\n", filePath)
-				} else {
-					cmd.PrintErrf("Error checking file path: %v\n", err)
+					return fmt.Errorf("file already exists at %s. Please specify a new file path", filePath)
 				}
-				return
+				return fmt.Errorf("error checking file path: %w", err)
 			}
 
 			profileRepo := profile.NewYamlProfileRepositoryImpl(filePath)
 			// テンプレートを使用してコメント付きprofile.ymlを生成
 			err := profileRepo.SaveProfileWithTemplate()
 			if err != nil {
-				cmd.PrintErrf("Failed to create profile file: %v\n", err)
-				return
+				return fmt.Errorf("failed to create profile file: %w", err)
 			}
 			cmd.Printf("Profile file created successfully at %s\n", filePath)
+			return nil
 		},
 	}
+	cmd.SilenceUsage = true
 	return cmd
 }
 
@@ -135,7 +135,8 @@ func makeProfileCheckCmd() *cobra.Command {
 			}
 
 			return nil
-		},
+			},
 	}
+	cmd.SilenceUsage = true
 	return cmd
 }

--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -135,7 +135,7 @@ func makeProfileCheckCmd() *cobra.Command {
 			}
 
 			return nil
-			},
+		},
 	}
 	cmd.SilenceUsage = true
 	return cmd

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -96,6 +96,7 @@ recommends one random article from the fetched list.`,
 	cmd.Flags().StringP("source", "s", "", "Path to a file containing a list of URLs")
 	cmd.Flags().StringP("profile", "p", "", "Path to a profile YAML file")
 
+	cmd.SilenceUsage = true
 	return cmd
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ func makeRootCmd() *cobra.Command {
 		Short: "An AI-powered CLI RSS reader that summarizes articles and posts comments to various platforms.",
 	}
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ./config.yml)")
+	cmd.SilenceUsage = true
 	return cmd
 }
 


### PR DESCRIPTION
## 概要
エラー発生時にUsageが表示されてエラー内容が埋もれる問題を修正。

## 対応内容
全コマンドに`SilenceUsage = true`を設定：
- ルートコマンド
- initコマンド
- profileコマンド
- profile initコマンド（RunEに変更）
- profile checkコマンド
- recommendコマンド

## テスト結果
- make build/lint/test: 全て成功
- エラー時にUsageが表示されないことを確認
- --helpオプションは正常に動作

fixed #106