### PR TITLE
デバッグログ出力機能の実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ go test -v ./...
 
 4. **外部連携**: SlackとMisskeyプラットフォームへの投稿をサポート。各連携はinternal/infra/内の個別のviewerとして実装されています。
 
+5. **ログシステム**: Go標準ライブラリのlog/slogパッケージを使用。verboseフラグ（-v, --verbose）でDEBUG/INFOレベルを切り替え可能です。
+
 ## コーディングルール
 
 詳細なコーディングルールは [docs/01_coding_rules.md](docs/01_coding_rules.md) を参照してください。

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"github.com/canpok1/ai-feed/internal/infra"
 	"github.com/canpok1/ai-feed/internal/infra/fetch"
 	"github.com/spf13/cobra"
 )
 
-var cfgFile string
+var (
+	cfgFile string
+	verbose bool
+)
 
 func makeRootCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -13,12 +17,18 @@ func makeRootCmd() *cobra.Command {
 		Short: "RSSフィードから記事を取得し、AIによる要約とコメント投稿を行うCLIツールです",
 	}
 	cmd.PersistentFlags().StringVar(&cfgFile, "config", "", "設定ファイル (デフォルトは ./config.yml)")
+	cmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "デバッグログを出力する")
 	cmd.SilenceUsage = true
 	return cmd
 }
 
 func Execute() error {
 	rootCmd := makeRootCmd()
+
+	// PersistentPreRunでロガーを初期化
+	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		infra.InitLogger(verbose)
+	}
 
 	recommendCmd := makeRecommendCmd(fetch.NewFetchClient())
 	rootCmd.AddCommand(recommendCmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -53,10 +53,8 @@ func TestVerboseFlag(t *testing.T) {
 			err := rootCmd.Execute()
 
 			// The help command returns an error for exit, which is expected
-			if tt.name != "no verbose flag" {
-				// For verbose flag tests, we expect the verbose variable to be set correctly
-				assert.Equal(t, tt.expectVerbose, verbose)
-			}
+			// For all cases, we expect the verbose variable to be set correctly
+			assert.Equal(t, tt.expectVerbose, verbose)
 
 			// For help commands, we don't care about the error as it's expected
 			_ = err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerboseFlag(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectVerbose bool
+	}{
+		{
+			name:          "no verbose flag",
+			args:          []string{"recommend", "--help"},
+			expectVerbose: false,
+		},
+		{
+			name:          "short verbose flag",
+			args:          []string{"-v", "recommend", "--help"},
+			expectVerbose: true,
+		},
+		{
+			name:          "long verbose flag",
+			args:          []string{"--verbose", "recommend", "--help"},
+			expectVerbose: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset verbose flag
+			verbose = false
+
+			// Create root command
+			rootCmd := makeRootCmd()
+
+			// Set args
+			rootCmd.SetArgs(tt.args)
+
+			// Capture output to suppress help text
+			var buf bytes.Buffer
+			rootCmd.SetOut(&buf)
+			rootCmd.SetErr(&buf)
+
+			// Execute command (this should set the verbose flag)
+			err := rootCmd.Execute()
+
+			// The help command returns an error for exit, which is expected
+			if tt.name != "no verbose flag" {
+				// For verbose flag tests, we expect the verbose variable to be set correctly
+				assert.Equal(t, tt.expectVerbose, verbose)
+			}
+
+			// For help commands, we don't care about the error as it's expected
+			_ = err
+		})
+	}
+}
+
+func TestLoggerInitialization(t *testing.T) {
+	// Save original default logger
+	originalDefault := slog.Default()
+	defer slog.SetDefault(originalDefault)
+
+	tests := []struct {
+		name    string
+		verbose bool
+	}{
+		{
+			name:    "logger initialization with verbose false",
+			verbose: false,
+		},
+		{
+			name:    "logger initialization with verbose true",
+			verbose: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set verbose flag
+			verbose = tt.verbose
+
+			// Create root command
+			rootCmd := makeRootCmd()
+
+			// Set up PersistentPreRun
+			rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+				// This would normally call infra.InitLogger(verbose)
+				// For testing, we'll just verify the verbose flag is set correctly
+				assert.Equal(t, tt.verbose, verbose)
+			}
+
+			// Set a dummy command to trigger PersistentPreRun
+			rootCmd.SetArgs([]string{"--help"})
+
+			// Capture output
+			var buf bytes.Buffer
+			rootCmd.SetOut(&buf)
+			rootCmd.SetErr(&buf)
+
+			// Execute - this should trigger PersistentPreRun
+			err := rootCmd.Execute()
+
+			// Help command exits with error, which is expected
+			_ = err
+		})
+	}
+}
+
+func TestRootCommandCreation(t *testing.T) {
+	cmd := makeRootCmd()
+
+	// Test basic command properties
+	assert.Equal(t, "ai-feed", cmd.Use)
+	assert.Contains(t, cmd.Short, "RSSフィードから記事を取得")
+	assert.True(t, cmd.SilenceUsage)
+
+	// Test flags
+	configFlag := cmd.PersistentFlags().Lookup("config")
+	assert.NotNil(t, configFlag)
+	assert.Equal(t, "", configFlag.DefValue)
+
+	verboseFlag := cmd.PersistentFlags().Lookup("verbose")
+	assert.NotNil(t, verboseFlag)
+	assert.Equal(t, "false", verboseFlag.DefValue)
+
+	// Test short flag for verbose
+	verboseFlagShort := cmd.PersistentFlags().ShorthandLookup("v")
+	assert.NotNil(t, verboseFlagShort)
+	assert.Equal(t, verboseFlag, verboseFlagShort)
+}
+
+func TestExecuteFunction(t *testing.T) {
+	// This test ensures Execute function can be called without panicking
+	// We'll redirect output to avoid printing to stdout during tests
+
+	// Save original stdout/stderr
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	// Set args to just show help to avoid actually running commands
+	os.Args = []string{"ai-feed", "--help"}
+
+	// The Execute function should not panic
+	assert.NotPanics(t, func() {
+		err := Execute()
+		// Help command returns an error (exit code), which is expected behavior
+		_ = err
+	})
+}

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 
 	"github.com/canpok1/ai-feed/internal/domain"
 	"github.com/canpok1/ai-feed/internal/infra"
@@ -72,19 +73,29 @@ func NewRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 
 // Run はrecommendコマンドのビジネスロジックを実行する
 func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, profile infra.Profile) error {
+	slog.Info("Starting recommend command execution")
+	slog.Debug("Fetching articles from URLs", "url_count", len(params.URLs))
+
 	allArticles, err := r.fetcher.Fetch(params.URLs, 0)
 	if err != nil {
 		return fmt.Errorf("failed to fetch articles: %w", err)
 	}
 
 	if len(allArticles) == 0 {
+		slog.Warn("No articles found in feeds")
 		return ErrNoArticlesFound
 	}
 
+	slog.Debug("Articles fetched successfully", "article_count", len(allArticles))
+
+	slog.Debug("Generating recommendation from articles")
 	recommend, err := r.recommender.Recommend(ctx, allArticles)
 	if err != nil {
+		slog.Error("Failed to generate recommendation", "error", err)
 		return fmt.Errorf("failed to recommend article: %w", err)
 	}
+
+	slog.Debug("Recommendation generated successfully", "article_title", recommend.Article.Title)
 
 	var errs []error
 	fixedMessage := ""
@@ -92,15 +103,19 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 		fixedMessage = profile.Prompt.FixedMessage
 	}
 
+	slog.Debug("Sending recommendation to viewers", "viewer_count", len(r.viewers))
 	for _, viewer := range r.viewers {
 		if viewErr := viewer.SendRecommend(recommend, fixedMessage); viewErr != nil {
+			slog.Error("Failed to send recommendation to viewer", "error", viewErr)
 			errs = append(errs, fmt.Errorf("failed to view recommend: %w", viewErr))
 		}
 	}
 
 	if len(errs) > 0 {
+		slog.Error("Some viewers failed to send recommendation", "error_count", len(errs))
 		return fmt.Errorf("failed to view all recommends: %v", errs)
 	}
 
+	slog.Info("Recommendation sent successfully to all viewers")
 	return nil
 }

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -105,7 +105,6 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 	slog.Debug("Sending recommendation to viewers", "viewer_count", len(r.viewers))
 	for _, viewer := range r.viewers {
 		if viewErr := viewer.SendRecommend(recommend, fixedMessage); viewErr != nil {
-			slog.Error("Failed to send recommendation to viewer", "error", viewErr)
 			errs = append(errs, fmt.Errorf("failed to view recommend: %w", viewErr))
 		}
 	}

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -91,7 +91,6 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 	slog.Debug("Generating recommendation from articles")
 	recommend, err := r.recommender.Recommend(ctx, allArticles)
 	if err != nil {
-		slog.Error("Failed to generate recommendation", "error", err)
 		return fmt.Errorf("failed to recommend article: %w", err)
 	}
 
@@ -112,7 +111,6 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 	}
 
 	if len(errs) > 0 {
-		slog.Error("Some viewers failed to send recommendation", "error_count", len(errs))
 		return fmt.Errorf("failed to view all recommends: %v", errs)
 	}
 

--- a/internal/infra/logger.go
+++ b/internal/infra/logger.go
@@ -1,10 +1,91 @@
 package infra
 
 import (
+	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"sync"
 	"time"
 )
+
+// SimpleHandler は時刻 ログレベル ログメッセージの形式で出力するカスタムハンドラー
+type SimpleHandler struct {
+	opts slog.HandlerOptions
+	mu   sync.Mutex
+	out  io.Writer
+}
+
+// NewSimpleHandler は新しいSimpleHandlerを作成する
+func NewSimpleHandler(out io.Writer, opts *slog.HandlerOptions) *SimpleHandler {
+	if opts == nil {
+		opts = &slog.HandlerOptions{}
+	}
+	return &SimpleHandler{
+		opts: *opts,
+		out:  out,
+	}
+}
+
+// Enabled はログレベルが有効かどうかを判定する
+func (h *SimpleHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.opts.Level.Level()
+}
+
+// Handle はログレコードを処理して出力する
+func (h *SimpleHandler) Handle(_ context.Context, r slog.Record) error {
+	var timestamp string
+	var level string
+	var msg string
+
+	// タイムスタンプを取得
+	timestamp = r.Time.Format(time.RFC3339)
+
+	// ログレベルを取得
+	level = r.Level.String()
+
+	// メッセージを取得
+	msg = r.Message
+
+	// 属性を追加
+	attrs := make([]string, 0)
+	r.Attrs(func(a slog.Attr) bool {
+		attrs = append(attrs, fmt.Sprintf("%s=%v", a.Key, a.Value.Any()))
+		return true
+	})
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// 出力形式: 時刻 ログレベル ログメッセージ [属性...]
+	if len(attrs) > 0 {
+		_, err := fmt.Fprintf(h.out, "%s %s %s", timestamp, level, msg)
+		if err != nil {
+			return err
+		}
+		for _, attr := range attrs {
+			_, err = fmt.Fprintf(h.out, " %s", attr)
+			if err != nil {
+				return err
+			}
+		}
+		_, err = fmt.Fprintln(h.out)
+		return err
+	}
+	_, err := fmt.Fprintf(h.out, "%s %s %s\n", timestamp, level, msg)
+	return err
+}
+
+// WithAttrs は属性を追加したハンドラーを返す（この実装では新しいハンドラーを返す）
+func (h *SimpleHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+// WithGroup はグループを追加したハンドラーを返す（この実装では新しいハンドラーを返す）
+func (h *SimpleHandler) WithGroup(name string) slog.Handler {
+	return h
+}
 
 // InitLogger はslogを使用したロガーを初期化する
 // verboseがtrueの場合はDEBUGレベル、falseの場合はINFOレベルで設定する
@@ -16,19 +97,9 @@ func InitLogger(verbose bool) {
 
 	opts := &slog.HandlerOptions{
 		Level: level,
-		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-			// タイムスタンプをRFC3339形式に変更
-			if a.Key == slog.TimeKey {
-				return slog.Attr{
-					Key:   a.Key,
-					Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
-				}
-			}
-			return a
-		},
 	}
 
-	handler := slog.NewTextHandler(os.Stdout, opts)
+	handler := NewSimpleHandler(os.Stdout, opts)
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 }

--- a/internal/infra/logger.go
+++ b/internal/infra/logger.go
@@ -1,0 +1,34 @@
+package infra
+
+import (
+	"log/slog"
+	"os"
+	"time"
+)
+
+// InitLogger はslogを使用したロガーを初期化する
+// verboseがtrueの場合はDEBUGレベル、falseの場合はINFOレベルで設定する
+func InitLogger(verbose bool) {
+	level := slog.LevelInfo
+	if verbose {
+		level = slog.LevelDebug
+	}
+
+	opts := &slog.HandlerOptions{
+		Level: level,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			// タイムスタンプをRFC3339形式に変更
+			if a.Key == slog.TimeKey {
+				return slog.Attr{
+					Key:   a.Key,
+					Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
+				}
+			}
+			return a
+		},
+	}
+
+	handler := slog.NewTextHandler(os.Stdout, opts)
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+}

--- a/internal/infra/logger_test.go
+++ b/internal/infra/logger_test.go
@@ -1,0 +1,165 @@
+package infra
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitLogger(t *testing.T) {
+	tests := []struct {
+		name     string
+		verbose  bool
+		logLevel slog.Level
+	}{
+		{
+			name:     "verbose false should set INFO level",
+			verbose:  false,
+			logLevel: slog.LevelInfo,
+		},
+		{
+			name:     "verbose true should set DEBUG level",
+			verbose:  true,
+			logLevel: slog.LevelDebug,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Capture output
+			var buf bytes.Buffer
+
+			// Mock the output destination for testing
+			originalHandler := slog.Default().Handler()
+
+			// Initialize logger with test configuration
+			opts := &slog.HandlerOptions{
+				Level: tt.logLevel,
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.TimeKey {
+						return slog.Attr{
+							Key:   a.Key,
+							Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
+						}
+					}
+					return a
+				},
+			}
+
+			handler := slog.NewTextHandler(&buf, opts)
+			logger := slog.New(handler)
+			slog.SetDefault(logger)
+
+			// Test different log levels
+			slog.Debug("debug message")
+			slog.Info("info message")
+			slog.Warn("warn message")
+			slog.Error("error message")
+
+			output := buf.String()
+
+			if tt.verbose {
+				// DEBUG level should show all messages
+				assert.Contains(t, output, "debug message")
+				assert.Contains(t, output, "info message")
+				assert.Contains(t, output, "warn message")
+				assert.Contains(t, output, "error message")
+			} else {
+				// INFO level should not show debug messages
+				assert.NotContains(t, output, "debug message")
+				assert.Contains(t, output, "info message")
+				assert.Contains(t, output, "warn message")
+				assert.Contains(t, output, "error message")
+			}
+
+			// Test timestamp format (RFC3339)
+			lines := strings.Split(strings.TrimSpace(output), "\n")
+			for _, line := range lines {
+				if strings.Contains(line, "time=") {
+					// Extract timestamp from log line
+					timePart := strings.Split(line, " ")[0]
+					timeValue := strings.TrimPrefix(timePart, "time=")
+					_, err := time.Parse(time.RFC3339, timeValue)
+					assert.NoError(t, err, "Timestamp should be in RFC3339 format")
+				}
+			}
+
+			// Restore original handler
+			slog.SetDefault(slog.New(originalHandler))
+		})
+	}
+}
+
+func TestInitLoggerIntegration(t *testing.T) {
+	// Test the actual InitLogger function
+	var buf bytes.Buffer
+
+	// Save original default logger
+	originalDefault := slog.Default()
+
+	// Test with verbose=false
+	t.Run("InitLogger with verbose=false", func(t *testing.T) {
+		InitLogger(false)
+
+		// Replace handler with test handler to capture output
+		opts := &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.TimeKey {
+					return slog.Attr{
+						Key:   a.Key,
+						Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
+					}
+				}
+				return a
+			},
+		}
+		handler := slog.NewTextHandler(&buf, opts)
+		logger := slog.New(handler)
+		slog.SetDefault(logger)
+
+		slog.Debug("debug message")
+		slog.Info("info message")
+
+		output := buf.String()
+		assert.NotContains(t, output, "debug message")
+		assert.Contains(t, output, "info message")
+	})
+
+	// Test with verbose=true
+	t.Run("InitLogger with verbose=true", func(t *testing.T) {
+		buf.Reset()
+		InitLogger(true)
+
+		// Replace handler with test handler to capture output
+		opts := &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+				if a.Key == slog.TimeKey {
+					return slog.Attr{
+						Key:   a.Key,
+						Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
+					}
+				}
+				return a
+			},
+		}
+		handler := slog.NewTextHandler(&buf, opts)
+		logger := slog.New(handler)
+		slog.SetDefault(logger)
+
+		slog.Debug("debug message")
+		slog.Info("info message")
+
+		output := buf.String()
+		assert.Contains(t, output, "debug message")
+		assert.Contains(t, output, "info message")
+	})
+
+	// Restore original default logger
+	slog.SetDefault(originalDefault)
+}

--- a/internal/infra/logger_test.go
+++ b/internal/infra/logger_test.go
@@ -2,7 +2,9 @@ package infra
 
 import (
 	"bytes"
+	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -11,155 +13,66 @@ import (
 )
 
 func TestInitLogger(t *testing.T) {
+	// 元のos.Stdoutとslogのデフォルトを保存
+	originalStdout := os.Stdout
+	originalLogger := slog.Default()
+	defer func() {
+		os.Stdout = originalStdout
+		slog.SetDefault(originalLogger)
+	}()
+
 	tests := []struct {
-		name     string
-		verbose  bool
-		logLevel slog.Level
+		name        string
+		verbose     bool
+		expectDebug bool
 	}{
 		{
-			name:     "verbose false should set INFO level",
-			verbose:  false,
-			logLevel: slog.LevelInfo,
+			name:        "verbose false should set INFO level",
+			verbose:     false,
+			expectDebug: false,
 		},
 		{
-			name:     "verbose true should set DEBUG level",
-			verbose:  true,
-			logLevel: slog.LevelDebug,
+			name:        "verbose true should set DEBUG level",
+			verbose:     true,
+			expectDebug: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Capture output
-			var buf bytes.Buffer
+			r, w, err := os.Pipe()
+			assert.NoError(t, err)
+			os.Stdout = w
 
-			// Mock the output destination for testing
-			originalHandler := slog.Default().Handler()
+			InitLogger(tt.verbose)
 
-			// Initialize logger with test configuration
-			opts := &slog.HandlerOptions{
-				Level: tt.logLevel,
-				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-					if a.Key == slog.TimeKey {
-						return slog.Attr{
-							Key:   a.Key,
-							Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
-						}
-					}
-					return a
-				},
-			}
-
-			handler := slog.NewTextHandler(&buf, opts)
-			logger := slog.New(handler)
-			slog.SetDefault(logger)
-
-			// Test different log levels
 			slog.Debug("debug message")
 			slog.Info("info message")
-			slog.Warn("warn message")
-			slog.Error("error message")
+
+			w.Close()
+			var buf bytes.Buffer
+			_, err = io.Copy(&buf, r)
+			assert.NoError(t, err)
 
 			output := buf.String()
 
-			if tt.verbose {
-				// DEBUG level should show all messages
+			if tt.expectDebug {
 				assert.Contains(t, output, "debug message")
-				assert.Contains(t, output, "info message")
-				assert.Contains(t, output, "warn message")
-				assert.Contains(t, output, "error message")
 			} else {
-				// INFO level should not show debug messages
 				assert.NotContains(t, output, "debug message")
-				assert.Contains(t, output, "info message")
-				assert.Contains(t, output, "warn message")
-				assert.Contains(t, output, "error message")
 			}
+			assert.Contains(t, output, "info message")
 
 			// Test timestamp format (RFC3339)
-			lines := strings.Split(strings.TrimSpace(output), "\n")
-			for _, line := range lines {
-				if strings.Contains(line, "time=") {
-					// Extract timestamp from log line
-					timePart := strings.Split(line, " ")[0]
+			if len(output) > 0 {
+				lines := strings.Split(strings.TrimSpace(output), "\n")
+				if len(lines) > 0 && lines[0] != "" {
+					timePart := strings.Split(lines[0], " ")[0]
 					timeValue := strings.TrimPrefix(timePart, "time=")
 					_, err := time.Parse(time.RFC3339, timeValue)
 					assert.NoError(t, err, "Timestamp should be in RFC3339 format")
 				}
 			}
-
-			// Restore original handler
-			slog.SetDefault(slog.New(originalHandler))
 		})
 	}
-}
-
-func TestInitLoggerIntegration(t *testing.T) {
-	// Test the actual InitLogger function
-	var buf bytes.Buffer
-
-	// Save original default logger
-	originalDefault := slog.Default()
-
-	// Test with verbose=false
-	t.Run("InitLogger with verbose=false", func(t *testing.T) {
-		InitLogger(false)
-
-		// Replace handler with test handler to capture output
-		opts := &slog.HandlerOptions{
-			Level: slog.LevelInfo,
-			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-				if a.Key == slog.TimeKey {
-					return slog.Attr{
-						Key:   a.Key,
-						Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
-					}
-				}
-				return a
-			},
-		}
-		handler := slog.NewTextHandler(&buf, opts)
-		logger := slog.New(handler)
-		slog.SetDefault(logger)
-
-		slog.Debug("debug message")
-		slog.Info("info message")
-
-		output := buf.String()
-		assert.NotContains(t, output, "debug message")
-		assert.Contains(t, output, "info message")
-	})
-
-	// Test with verbose=true
-	t.Run("InitLogger with verbose=true", func(t *testing.T) {
-		buf.Reset()
-		InitLogger(true)
-
-		// Replace handler with test handler to capture output
-		opts := &slog.HandlerOptions{
-			Level: slog.LevelDebug,
-			ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-				if a.Key == slog.TimeKey {
-					return slog.Attr{
-						Key:   a.Key,
-						Value: slog.StringValue(a.Value.Time().Format(time.RFC3339)),
-					}
-				}
-				return a
-			},
-		}
-		handler := slog.NewTextHandler(&buf, opts)
-		logger := slog.New(handler)
-		slog.SetDefault(logger)
-
-		slog.Debug("debug message")
-		slog.Info("info message")
-
-		output := buf.String()
-		assert.Contains(t, output, "debug message")
-		assert.Contains(t, output, "info message")
-	})
-
-	// Restore original default logger
-	slog.SetDefault(originalDefault)
 }


### PR DESCRIPTION
## 概要
log/slogパッケージを使用したデバッグログ出力機能を実装

## 変更内容
- verboseフラグ（-v, --verbose）でDEBUG/INFOレベルの切り替え
- RFC3339形式のタイムスタンプでテキスト出力
- recommendコマンドでのサンプル実装
- ロガー機能のテスト追加

## 動作確認
```bash
# 通常実行（INFOレベル）
./ai-feed recommend -u "URL"

# デバッグ実行（DEBUGレベル）  
./ai-feed -v recommend -u "URL"
```

fixed #110

🤖 Generated with [Claude Code](https://claude.ai/code)