### PR TITLE
ログの色付け機能を実装 #112

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,40 @@ AI Feedは指定RSSフィードからランダム選択した記事をAIの感�
     ./ai-feed recommend --url {任意のRSSフィードのURL}
     ```
 
+## ログの色付け
+
+ai-feedはログレベルごとに色を付けて視認性を向上させます：
+
+- **DEBUG**: 灰色
+- **INFO**: 緑色  
+- **WARN**: 黄色
+- **ERROR**: 赤色
+
+### 色の無効化
+
+以下の場合、色付けは自動的に無効化されます：
+- パイプやファイルリダイレクト時
+- CI環境での実行時
+- `NO_COLOR` 環境変数が設定されている時
+
+手動で色を無効化する場合：
+```bash
+# 色なしでアプリケーションを実行
+NO_COLOR=1 ./ai-feed recommend --url {RSS URL}
+
+# 環境変数として設定
+export NO_COLOR=1
+./ai-feed recommend --url {RSS URL}
+```
+
+### サポート環境
+
+ログの色付け機能は以下の環境でサポートされます：
+- Unix/Linux
+- macOS
+
+Windows環境では色付けされません。
+
 ## 開発環境
 
 ### 必要条件

--- a/internal/infra/logger.go
+++ b/internal/infra/logger.go
@@ -8,6 +8,15 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"github.com/fatih/color"
+)
+
+var (
+	debugColor = color.New(color.FgHiBlack) // 灰色
+	infoColor  = color.New(color.FgGreen)   // 緑色
+	warnColor  = color.New(color.FgYellow)  // 黄色
+	errorColor = color.New(color.FgRed)     // 赤色
 )
 
 // SimpleHandler は時刻 ログレベル ログメッセージの形式で出力するカスタムハンドラー
@@ -42,8 +51,20 @@ func (h *SimpleHandler) Handle(_ context.Context, r slog.Record) error {
 	// タイムスタンプを取得
 	timestamp = r.Time.Format(time.RFC3339)
 
-	// ログレベルを取得
-	level = r.Level.String()
+	// ログレベルを取得し、色を適用
+	levelStr := r.Level.String()
+	switch r.Level {
+	case slog.LevelDebug:
+		level = debugColor.Sprint(levelStr)
+	case slog.LevelInfo:
+		level = infoColor.Sprint(levelStr)
+	case slog.LevelWarn:
+		level = warnColor.Sprint(levelStr)
+	case slog.LevelError:
+		level = errorColor.Sprint(levelStr)
+	default:
+		level = levelStr
+	}
 
 	// メッセージを取得
 	msg = r.Message

--- a/internal/infra/logger_test.go
+++ b/internal/infra/logger_test.go
@@ -16,6 +16,11 @@ import (
 )
 
 func TestInitLogger(t *testing.T) {
+	// 色を無効化してテスト環境をシンプルに保つ
+	originalNoColor := color.NoColor
+	defer func() { color.NoColor = originalNoColor }()
+	color.NoColor = true
+
 	// 元のos.Stdoutとslogのデフォルトを保存
 	originalStdout := os.Stdout
 	originalLogger := slog.Default()
@@ -90,6 +95,11 @@ func TestInitLogger(t *testing.T) {
 }
 
 func TestSimpleHandler(t *testing.T) {
+	// 色を無効化してテスト環境をシンプルに保つ
+	originalNoColor := color.NoColor
+	defer func() { color.NoColor = originalNoColor }()
+	color.NoColor = true
+
 	tests := []struct {
 		name          string
 		level         slog.Level
@@ -162,10 +172,19 @@ func TestSimpleHandler(t *testing.T) {
 }
 
 func TestSimpleHandler_Handle_WithColors(t *testing.T) {
-	// color.NoColorを一時的に無効化
+	// NO_COLOR環境変数を一時的に無効化し、color.NoColorを無効化
+	originalEnv := os.Getenv("NO_COLOR")
 	originalNoColor := color.NoColor
-	defer func() { color.NoColor = originalNoColor }()
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("NO_COLOR", originalEnv)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+		color.NoColor = originalNoColor
+	}()
 
+	os.Unsetenv("NO_COLOR")
 	color.NoColor = false
 
 	tests := []struct {
@@ -207,10 +226,19 @@ func TestSimpleHandler_Handle_WithColors(t *testing.T) {
 }
 
 func TestSimpleHandler_Handle_NoColor(t *testing.T) {
-	// color.NoColorを一時的に有効化
+	// NO_COLOR環境変数を設定し、color.NoColorを有効化
+	originalEnv := os.Getenv("NO_COLOR")
 	originalNoColor := color.NoColor
-	defer func() { color.NoColor = originalNoColor }()
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv("NO_COLOR", originalEnv)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+		color.NoColor = originalNoColor
+	}()
 
+	os.Setenv("NO_COLOR", "1")
 	color.NoColor = true
 
 	var buf bytes.Buffer

--- a/internal/infra/logger_test.go
+++ b/internal/infra/logger_test.go
@@ -2,13 +2,16 @@ package infra
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -156,4 +159,77 @@ func TestSimpleHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSimpleHandler_Handle_WithColors(t *testing.T) {
+	// color.NoColorを一時的に無効化
+	originalNoColor := color.NoColor
+	defer func() { color.NoColor = originalNoColor }()
+
+	color.NoColor = false
+
+	tests := []struct {
+		name      string
+		level     slog.Level
+		colorCode string
+	}{
+		{"DEBUG with gray", slog.LevelDebug, "\\033\\[90m"},
+		{"INFO with green", slog.LevelInfo, "\\033\\[32m"},
+		{"WARN with yellow", slog.LevelWarn, "\\033\\[33m"},
+		{"ERROR with red", slog.LevelError, "\\033\\[31m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			handler := NewSimpleHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+			record := slog.Record{
+				Level:   tt.level,
+				Message: "test message",
+				Time:    time.Now(),
+			}
+
+			err := handler.Handle(context.Background(), record)
+			assert.NoError(t, err)
+
+			output := buf.String()
+			matched, err := regexp.MatchString(tt.colorCode, output)
+			assert.NoError(t, err)
+			assert.True(t, matched, "Expected color code %s not found in output: %s", tt.colorCode, output)
+
+			// リセットコード（\033[0m）も確認
+			resetMatched, err := regexp.MatchString("\\033\\[0m", output)
+			assert.NoError(t, err)
+			assert.True(t, resetMatched, "Expected reset code \\033[0m not found in output: %s", output)
+		})
+	}
+}
+
+func TestSimpleHandler_Handle_NoColor(t *testing.T) {
+	// color.NoColorを一時的に有効化
+	originalNoColor := color.NoColor
+	defer func() { color.NoColor = originalNoColor }()
+
+	color.NoColor = true
+
+	var buf bytes.Buffer
+	handler := NewSimpleHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+
+	record := slog.Record{
+		Level:   slog.LevelError,
+		Message: "test message",
+		Time:    time.Now(),
+	}
+
+	err := handler.Handle(context.Background(), record)
+	assert.NoError(t, err)
+
+	output := buf.String()
+	matched, err := regexp.MatchString("\\033\\[", output)
+	assert.NoError(t, err)
+	assert.False(t, matched, "ANSI escape codes should not be present when NO_COLOR is set: %s", output)
+
+	// プレーンテキストのログレベルが含まれることを確認
+	assert.Contains(t, output, "ERROR test message")
 }


### PR DESCRIPTION
## Summary
ログレベル別の色付け機能を実装し、視認性を向上

- DEBUG: 灰色
- INFO: 緑色
- WARN: 黄色
- ERROR: 赤色

## Changes
- fatih/colorパッケージを使用して色付けを実装
- NO_COLOR環境変数対応
- 自動色無効化（パイプ・リダイレクト・CI環境）
- 包括的テストカバレッジ
- README更新

fixed #112

🤖 Generated with [Claude Code](https://claude.ai/code)