### PR TITLE
go installでインストールしたバイナリでも適切なバージョンを表示

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,11 +1,30 @@
 package cmd
 
 import (
+	"runtime/debug"
+
 	"github.com/spf13/cobra"
 )
 
 // version はビルド時にldflags で埋め込まれるバージョン情報
 var version = "dev"
+
+// getVersion はバージョン情報を取得する
+// ビルド時に設定されたバージョンを優先し、"dev"の場合はビルド情報から取得する
+func getVersion() string {
+	if version != "dev" {
+		return version
+	}
+
+	// go installでビルドされた場合、ビルド情報からバージョンを取得
+	if info, ok := debug.ReadBuildInfo(); ok {
+		if info.Main.Version != "(devel)" && info.Main.Version != "" {
+			return info.Main.Version
+		}
+	}
+
+	return "dev"
+}
 
 // makeVersionCmd はversionコマンドを生成する
 func makeVersionCmd() *cobra.Command {
@@ -13,7 +32,7 @@ func makeVersionCmd() *cobra.Command {
 		Use:   "version",
 		Short: "バージョン情報を表示",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmd.Println(version)
+			cmd.Println(getVersion())
 			return nil
 		},
 	}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"runtime/debug"
 	"strings"
 	"testing"
 )
@@ -45,5 +46,45 @@ func TestVersionCommand(t *testing.T) {
 				t.Errorf("期待される出力は %q ですが、実際は %q でした", tc.want, got)
 			}
 		})
+	}
+}
+
+// TestGetVersion はgetVersion関数の動作を確認する
+func TestGetVersion(t *testing.T) {
+	t.Run("ビルド時バージョンが設定されている場合", func(t *testing.T) {
+		originalVersion := version
+		version = "v1.2.3"
+		defer func() { version = originalVersion }()
+
+		got := getVersion()
+		if got != "v1.2.3" {
+			t.Errorf("期待される結果は v1.2.3 ですが、実際は %s でした", got)
+		}
+	})
+
+	t.Run("ビルド時バージョンがdevの場合", func(t *testing.T) {
+		originalVersion := version
+		version = "dev"
+		defer func() { version = originalVersion }()
+
+		// ビルド情報がない場合は"dev"が返される
+		got := getVersion()
+		// この環境ではビルド情報が取得できない可能性があるため、
+		// "dev"または実際のバージョンのどちらかが返されることを許容
+		if got != "dev" && !strings.HasPrefix(got, "v") {
+			t.Errorf("期待される結果は dev またはバージョン文字列ですが、実際は %s でした", got)
+		}
+	})
+}
+
+// TestGetVersionWithMockBuildInfo はgo:embedなどでビルド情報が取得できる場合のテスト
+func TestGetVersionWithMockBuildInfo(t *testing.T) {
+	// このテストは実際のビルド情報に依存するため、
+	// ビルド環境での動作を確認するためのもの
+	if info, ok := debug.ReadBuildInfo(); ok {
+		t.Logf("BuildInfo.Main.Version: %s", info.Main.Version)
+		t.Logf("BuildInfo.Main.Path: %s", info.Main.Path)
+	} else {
+		t.Log("BuildInfoが取得できません")
 	}
 }


### PR DESCRIPTION
## Summary
- `go install`でインストールしたバイナリが適切なバージョンを表示するよう修正
- `runtime/debug.ReadBuildInfo()`を使用してビルド情報からバージョン取得
- git未インストール環境でも動作

## Test plan
- [x] makeビルドでバージョン表示確認
- [x] go installでバージョン表示確認
- [x] テストケース追加・実行

🤖 Generated with [Claude Code](https://claude.ai/code)