### PR TITLE
feat: 複数feedからの2段階ランダム選択とresilentエラーハンドリングの実装

### DIFF
--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 
 	"github.com/canpok1/ai-feed/internal/domain"
 	"github.com/canpok1/ai-feed/internal/domain/entity"
@@ -73,22 +74,81 @@ func NewRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 	}, nil
 }
 
+// selectRandomFeed は利用可能なfeed URLからランダムに1つを選択する
+func selectRandomFeed(urls []string, excludedURLs map[string]bool) (string, error) {
+	var availableURLs []string
+	for _, url := range urls {
+		if !excludedURLs[url] {
+			availableURLs = append(availableURLs, url)
+		}
+	}
+
+	if len(availableURLs) == 0 {
+		return "", errors.New("no available feeds")
+	}
+
+	return availableURLs[rand.Intn(len(availableURLs))], nil
+}
+
 // Run はrecommendコマンドのビジネスロジックを実行する
 func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, profile *entity.Profile) error {
 	slog.Info("Starting recommend command execution")
-	slog.Debug("Fetching articles from URLs", "url_count", len(params.URLs))
+	slog.Debug("Selecting feed from URLs", "url_count", len(params.URLs))
 
-	allArticles, err := r.fetcher.Fetch(params.URLs, 0)
-	if err != nil {
-		return fmt.Errorf("failed to fetch articles: %w", err)
+	// 複数feedからの2段階ランダム選択とリトライロジック
+	excludedURLs := make(map[string]bool)
+	var allArticles []entity.Article
+	var selectedURL string
+
+	for attempt := 1; attempt <= len(params.URLs); attempt++ {
+		// Step 1: ランダムに1つのfeedを選択
+		var err error
+		selectedURL, err = selectRandomFeed(params.URLs, excludedURLs)
+		if err != nil {
+			slog.Error("Failed to select feed", "error", err, "attempt", attempt, "total_feeds", len(params.URLs))
+			break
+		}
+
+		slog.Debug("Selected feed for articles fetch", "url", selectedURL, "attempt", attempt)
+
+		// Step 2: 選択されたfeedから記事を取得
+		allArticles, err = r.fetcher.Fetch([]string{selectedURL}, 0)
+		if err != nil {
+			slog.Warn("Failed to fetch from feed, retrying with another feed",
+				"url", selectedURL,
+				"error", err.Error(),
+				"attempt", attempt,
+				"total_feeds", len(params.URLs))
+			excludedURLs[selectedURL] = true
+			continue
+		}
+
+		// 記事が0件の場合もエラーとして扱う
+		if len(allArticles) == 0 {
+			slog.Warn("No articles found in feed, retrying with another feed",
+				"url", selectedURL,
+				"attempt", attempt,
+				"total_feeds", len(params.URLs))
+			excludedURLs[selectedURL] = true
+			continue
+		}
+
+		// 成功した場合
+		slog.Info("Successfully fetched articles from feed", "url", selectedURL, "article_count", len(allArticles))
+		break
 	}
 
+	// 全feedが失敗した場合
 	if len(allArticles) == 0 {
-		slog.Warn("No articles found in feeds")
+		var triedURLs []string
+		var errors []string
+		for _, url := range params.URLs {
+			triedURLs = append(triedURLs, url)
+			errors = append(errors, url+": failed")
+		}
+		slog.Error("Failed to fetch from all feeds", "tried_urls", triedURLs, "errors", errors)
 		return ErrNoArticlesFound
 	}
-
-	slog.Debug("Articles fetched successfully", "article_count", len(allArticles))
 
 	slog.Debug("Generating recommendation from articles")
 	recommend, err := r.recommender.Recommend(ctx, allArticles)

--- a/cmd/runner/recommend_test.go
+++ b/cmd/runner/recommend_test.go
@@ -176,7 +176,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 			params: &RecommendParams{
 				URLs: []string{"http://invalid.com/feed.xml"},
 			},
-			expectedErrorMessage: toStringP("failed to fetch articles: mock fetch error"),
+			expectedErrorMessage: toStringP("no articles found in the feed"),
 		},
 		{
 			name: "Recommend error",


### PR DESCRIPTION
## 概要
複数feedからの2段階ランダム選択とresilentなエラーハンドリングを実装しました。

## 実装内容
### 2段階ランダム選択
- Step 1: 複数のfeed URLからランダムに1つを選択
- Step 2: 選択されたfeedから記事を取得し、記事からランダムに1つを選択

### Resilentなエラーハンドリング
- 各feedは最大1回のみ試行（同一feedへの再試行なし）
- 失敗したfeedは除外リストに追加し、他のfeedで再試行
- 記事0件の場合もエラーとして扱い、他のfeedで再試行
- すべてのエラー種別（ネットワークエラー、タイムアウト、パースエラー）を統一処理

### ログ出力
- **WARN**: feed取得失敗時に他feedで再試行する際の詳細ログ
- **ERROR**: 全feed失敗時のエラーログ（試行URL一覧付き）
- **INFO**: 記事取得成功時の詳細ログ

## テスト結果
- 既存テストのエラーメッセージを新しいロジックに合わせて修正
- 全テストが成功（PASS）
- lintエラーなし
- ビルド成功

## 関連issue
fixed #133

🤖 Generated with [Claude Code](https://claude.ai/code)