### PR TITLE
feat: ログ出力形式統一とメッセージの二言語化

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -30,7 +30,8 @@ func makeRecommendCmd(fetchClient domain.FetchClient) *cobra.Command {
 			slog.Debug("Loading config", "config_path", configPath)
 			config, loadErr := infra.NewYamlConfigRepository(configPath).Load()
 			if loadErr != nil {
-				slog.Error("Failed to load config", "error", loadErr)
+				fmt.Fprintf(cmd.ErrOrStderr(), "エラー: 設定ファイルの読み込みに失敗しました: %s\n", configPath)
+				slog.Error("Failed to load config", "config_path", configPath, "error", loadErr)
 				return fmt.Errorf("failed to load config: %w", loadErr)
 			}
 
@@ -56,6 +57,7 @@ func makeRecommendCmd(fetchClient domain.FetchClient) *cobra.Command {
 				slog.Debug("Loading profile", "profile_path", profilePath)
 				loadedProfile, loadProfileErr := profile.NewYamlProfileRepositoryImpl(profilePath).LoadProfile()
 				if loadProfileErr != nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "エラー: プロファイルファイルの読み込みに失敗しました: %s\n", profilePath)
 					slog.Error("Failed to load profile", "profile_path", profilePath, "error", loadProfileErr)
 					return fmt.Errorf("failed to load profile from %s: %w", profilePath, loadProfileErr)
 				}

--- a/cmd/runner/profile_check.go
+++ b/cmd/runner/profile_check.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/canpok1/ai-feed/internal/domain"
@@ -47,7 +48,8 @@ func (r *ProfileCheckRunner) Run(profilePath string) (*ProfileCheckResult, error
 		// ファイルが存在しない場合は警告を表示しない
 		if _, statErr := os.Stat(r.configPath); !os.IsNotExist(statErr) {
 			// ファイルが存在するが読み込み・パースに失敗した場合は警告を表示
-			fmt.Fprintf(r.stderr, "警告: %s の読み込みまたは解析に失敗しました。空のデフォルトプロファイルで続行します。エラー: %v\n", r.configPath, err)
+			fmt.Fprintf(r.stderr, "警告: %s の読み込みまたは解析に失敗しました。空のデフォルトプロファイルで継続します。\n", r.configPath)
+			slog.Warn("Failed to load or parse config file, continuing with empty default profile", "config_path", r.configPath, "error", err)
 		}
 	} else {
 		config = loadedConfig

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -33,7 +33,8 @@ func NewRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 	fetcher := domain.NewFetcher(
 		fetchClient,
 		func(url string, err error) error {
-			fmt.Fprintf(stderr, "Error fetching feed from %s: %v\n", url, err)
+			fmt.Fprintf(stderr, "エラー: フィードの取得に失敗しました: %s\n", url)
+			slog.Error("Failed to fetch feed", "url", url, "error", err)
 			return err
 		},
 	)

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -46,7 +46,7 @@ func NewRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 			slackConfig := outputConfig.SlackAPI
 			// enabledフラグのチェック
 			if !slackConfig.Enabled {
-				slog.Info("Slack API出力が無効化されています (enabled: false)")
+				slog.Info("Slack API output is disabled (enabled: false)")
 			} else {
 				slackViewer := message.NewSlackSender(slackConfig)
 				viewers = append(viewers, slackViewer)
@@ -57,7 +57,7 @@ func NewRecommendRunner(fetchClient domain.FetchClient, recommender domain.Recom
 			misskeyConfig := outputConfig.Misskey
 			// enabledフラグのチェック
 			if !misskeyConfig.Enabled {
-				slog.Info("Misskey出力が無効化されています (enabled: false)")
+				slog.Info("Misskey output is disabled (enabled: false)")
 			} else {
 				misskeyViewer, err := message.NewMisskeySender(misskeyConfig.APIURL, misskeyConfig.APIToken, misskeyConfig.MessageTemplate)
 				if err != nil {
@@ -174,7 +174,7 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 	if recommend.Comment != nil {
 		commentValue = *recommend.Comment
 	}
-	slog.Info("推薦記事を選択しました",
+	slog.Info("Recommendation article selected",
 		"title", recommend.Article.Title,
 		"link", recommend.Article.Link,
 		"comment", commentValue,

--- a/cmd/runner/recommend_test.go
+++ b/cmd/runner/recommend_test.go
@@ -339,7 +339,7 @@ func TestRecommendRunner_Run_LogOutput(t *testing.T) {
 	lines := bytes.Split(logBuffer.Bytes(), []byte("\n"))
 	var recommendLogLine []byte
 	for _, line := range lines {
-		if len(line) > 0 && bytes.Contains(line, []byte("推薦記事を選択しました")) {
+		if len(line) > 0 && bytes.Contains(line, []byte("Recommendation article selected")) {
 			recommendLogLine = line
 			break
 		}
@@ -349,7 +349,7 @@ func TestRecommendRunner_Run_LogOutput(t *testing.T) {
 	require.NoError(t, json.Unmarshal(recommendLogLine, &logEntry))
 
 	assert.Equal(t, "INFO", logEntry["level"])
-	assert.Equal(t, "推薦記事を選択しました", logEntry["msg"])
+	assert.Equal(t, "Recommendation article selected", logEntry["msg"])
 	assert.Equal(t, "Test Article", logEntry["title"])
 	assert.Equal(t, "https://example.com/test", logEntry["link"])
 	assert.Equal(t, "This is a test comment", logEntry["comment"])
@@ -477,7 +477,7 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
-			expectedLogs: []string{"Slack API出力が無効化されています (enabled: false)"},
+			expectedLogs: []string{"Slack API output is disabled (enabled: false)"},
 		},
 		{
 			name: "Misskey無効ログ確認",
@@ -489,7 +489,7 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
-			expectedLogs: []string{"Misskey出力が無効化されています (enabled: false)"},
+			expectedLogs: []string{"Misskey output is disabled (enabled: false)"},
 		},
 		{
 			name: "両方無効ログ確認",
@@ -508,8 +508,8 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 				},
 			},
 			expectedLogs: []string{
-				"Slack API出力が無効化されています (enabled: false)",
-				"Misskey出力が無効化されています (enabled: false)",
+				"Slack API output is disabled (enabled: false)",
+				"Misskey output is disabled (enabled: false)",
 			},
 		},
 	}

--- a/internal/infra/logger.go
+++ b/internal/infra/logger.go
@@ -102,18 +102,23 @@ func (h *SimpleHandler) WithGroup(name string) slog.Handler {
 }
 
 // InitLogger はslogを使用したロガーを初期化する
-// verboseがtrueの場合はDEBUGレベル、falseの場合はINFOレベルで設定する
+// verboseがtrueの場合はDEBUGレベルをstderrに出力、falseの場合はログを出力しない
 func InitLogger(verbose bool) {
-	level := slog.LevelInfo
-	if verbose {
-		level = slog.LevelDebug
+	if !verbose {
+		// -vなしの場合はログを出力しない
+		handler := slog.NewTextHandler(io.Discard, nil)
+		logger := slog.New(handler)
+		slog.SetDefault(logger)
+		return
 	}
 
+	// -vありの場合はDEBUGレベル以上をstderrに出力
+	level := slog.LevelDebug
 	opts := &slog.HandlerOptions{
 		Level: level,
 	}
 
-	handler := NewSimpleHandler(os.Stdout, opts)
+	handler := NewSimpleHandler(os.Stderr, opts)
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 }

--- a/internal/infra/logger.go
+++ b/internal/infra/logger.go
@@ -104,21 +104,18 @@ func (h *SimpleHandler) WithGroup(name string) slog.Handler {
 // InitLogger はslogを使用したロガーを初期化する
 // verboseがtrueの場合はDEBUGレベルをstderrに出力、falseの場合はログを出力しない
 func InitLogger(verbose bool) {
+	var handler slog.Handler
 	if !verbose {
 		// -vなしの場合はログを出力しない
-		handler := slog.NewTextHandler(io.Discard, nil)
-		logger := slog.New(handler)
-		slog.SetDefault(logger)
-		return
+		handler = slog.NewTextHandler(io.Discard, nil)
+	} else {
+		// -vありの場合はDEBUGレベル以上をstderrに出力
+		opts := &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}
+		handler = NewSimpleHandler(os.Stderr, opts)
 	}
 
-	// -vありの場合はDEBUGレベル以上をstderrに出力
-	level := slog.LevelDebug
-	opts := &slog.HandlerOptions{
-		Level: level,
-	}
-
-	handler := NewSimpleHandler(os.Stderr, opts)
 	logger := slog.New(handler)
 	slog.SetDefault(logger)
 }


### PR DESCRIPTION
## 概要
ログ出力形式の統一と-vオプション仕様変更を実装

## 変更内容
- `-v`なし: slogログを出力しない
- `-v`あり: DEBUGレベル以上をstderrに出力
- ユーザー向けメッセージ: 日本語
- 開発者向けslogメッセージ: 英語（文字化けリスク回避）
- fmt.Fprintfによる混在ログをslog + ユーザーメッセージに分離

fixed #138

🤖 Generated with [Claude Code](https://claude.ai/code)