### PR TITLE
feat: recommendコマンド用キャッシュ機能の実装 #142

### DIFF
--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -73,7 +73,17 @@ func makeRecommendCmd(fetchClient domain.FetchClient) *cobra.Command {
 				currentProfile.Prompt,
 			)
 
-			recommendRunner, runnerErr := runner.NewRecommendRunner(fetchClient, recommender, cmd.ErrOrStderr(), cmd.OutOrStdout(), currentProfile.Output, currentProfile.Prompt, currentProfile.Cache)
+			// キャッシュ設定の取得（Config.Cacheから）
+			var cacheEntity *entity.CacheConfig
+			if config.Cache != nil {
+				var err error
+				cacheEntity, err = config.Cache.ToEntity()
+				if err != nil {
+					return fmt.Errorf("failed to process cache config: %w", err)
+				}
+			}
+
+			recommendRunner, runnerErr := runner.NewRecommendRunner(fetchClient, recommender, cmd.ErrOrStderr(), cmd.OutOrStdout(), currentProfile.Output, currentProfile.Prompt, cacheEntity)
 			if runnerErr != nil {
 				return fmt.Errorf("failed to create runner: %w", runnerErr)
 			}

--- a/cmd/recommend.go
+++ b/cmd/recommend.go
@@ -73,7 +73,7 @@ func makeRecommendCmd(fetchClient domain.FetchClient) *cobra.Command {
 				currentProfile.Prompt,
 			)
 
-			recommendRunner, runnerErr := runner.NewRecommendRunner(fetchClient, recommender, cmd.ErrOrStderr(), cmd.OutOrStdout(), currentProfile.Output, currentProfile.Prompt)
+			recommendRunner, runnerErr := runner.NewRecommendRunner(fetchClient, recommender, cmd.ErrOrStderr(), cmd.OutOrStdout(), currentProfile.Output, currentProfile.Prompt, currentProfile.Cache)
 			if runnerErr != nil {
 				return fmt.Errorf("failed to create runner: %w", runnerErr)
 			}

--- a/cmd/runner/recommend.go
+++ b/cmd/runner/recommend.go
@@ -210,7 +210,7 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 	fmt.Fprintln(r.stderr, "記事の重複をチェックしています...")
 	var uniqueArticles []entity.Article
 	duplicateCount := 0
-	
+
 	for _, article := range allArticles {
 		if r.cache.IsCached(article.Link) {
 			duplicateCount++
@@ -220,9 +220,9 @@ func (r *RecommendRunner) Run(ctx context.Context, params *RecommendParams, prof
 		}
 	}
 
-	slog.Info("Cache duplicate check completed", 
-		"total_articles", len(allArticles), 
-		"duplicate_articles", duplicateCount, 
+	slog.Info("Cache duplicate check completed",
+		"total_articles", len(allArticles),
+		"duplicate_articles", duplicateCount,
 		"unique_articles", len(uniqueArticles))
 
 	// 全ての記事が重複している場合

--- a/cmd/runner/recommend_test.go
+++ b/cmd/runner/recommend_test.go
@@ -104,6 +104,7 @@ func TestNewRecommendRunner(t *testing.T) {
 				stdoutBuffer,
 				tt.outputConfig,
 				tt.promptConfig,
+				nil, // cacheConfig
 			)
 
 			if tt.expectError {
@@ -253,11 +254,11 @@ func TestRecommendRunner_Run(t *testing.T) {
 			switch tt.name {
 			case "Successful recommendation", "No articles found", "Recommend error", "Fetch error":
 				stdoutBuffer := new(bytes.Buffer)
-				runner, runErr = NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, mockProfile.Output, mockProfile.Prompt)
+				runner, runErr = NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, mockProfile.Output, mockProfile.Prompt, nil)
 				profile = mockProfile
 			case "AI model not configured":
 				stdoutBuffer := new(bytes.Buffer)
-				runner, runErr = NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, &entity.OutputConfig{}, &entity.PromptConfig{})
+				runner, runErr = NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, &entity.OutputConfig{}, &entity.PromptConfig{}, nil)
 				profile = &entity.Profile{
 					AI:     nil,
 					Prompt: mockProfile.Prompt,
@@ -265,7 +266,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 				}
 			case "Prompt not configured":
 				stdoutBuffer := new(bytes.Buffer)
-				runner, runErr = NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, &entity.OutputConfig{}, &entity.PromptConfig{})
+				runner, runErr = NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, &entity.OutputConfig{}, &entity.PromptConfig{}, nil)
 				profile = &entity.Profile{
 					AI:     mockProfile.AI,
 					Prompt: nil,
@@ -312,7 +313,7 @@ func TestRecommendRunner_Run_LogOutput(t *testing.T) {
 	mockProfile := createMockConfig(&entity.PromptConfig{CommentPromptTemplate: "test-prompt-template", FixedMessage: "Test Fixed Message"}, &entity.OutputConfig{})
 
 	stdoutBuffer := new(bytes.Buffer)
-	runner, runErr := NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, mockProfile.Output, mockProfile.Prompt)
+	runner, runErr := NewRecommendRunner(mockFetchClient, mockRecommender, stderrBuffer, stdoutBuffer, mockProfile.Output, mockProfile.Prompt, nil)
 	assert.NoError(t, runErr)
 
 	// Set up test data
@@ -460,6 +461,7 @@ func TestNewRecommendRunner_EnabledFlags(t *testing.T) {
 				stdoutBuffer,
 				tt.outputConfig,
 				&entity.PromptConfig{},
+				nil, // cacheConfig
 			)
 
 			assert.NoError(t, err)
@@ -549,6 +551,7 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 				stdoutBuffer,
 				tt.outputConfig,
 				&entity.PromptConfig{},
+				nil, // cacheConfig
 			)
 
 			assert.NoError(t, err)
@@ -595,6 +598,7 @@ func TestRecommendRunner_Run_AllOutputsDisabled(t *testing.T) {
 		new(bytes.Buffer), // stdout buffer
 		outputConfig,
 		&entity.PromptConfig{},
+		nil, // cacheConfig
 	)
 
 	assert.NoError(t, err)

--- a/internal/domain/cache.go
+++ b/internal/domain/cache.go
@@ -1,0 +1,43 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+// RecommendEntry represents a single cache entry for recommended articles
+type RecommendEntry struct {
+	URL      string    `json:"url"`
+	Title    string    `json:"title"`
+	PostedAt time.Time `json:"posted_at"`
+}
+
+// RecommendCache provides an interface for managing recommend article cache
+type RecommendCache interface {
+	// Initialize initializes the cache, loads existing data and acquires necessary locks
+	Initialize() error
+
+	// IsCached checks if the given URL is already cached (duplicate check)
+	IsCached(url string) bool
+
+	// AddEntry adds a new entry to the cache with the given URL and title
+	AddEntry(url, title string) error
+
+	// Close closes the cache, releases locks and performs cleanup
+	Close() error
+}
+
+// Cache-related errors
+var (
+	// ErrCacheLocked is returned when cache file is already locked by another process
+	ErrCacheLocked = errors.New("cache file is locked by another process")
+
+	// ErrCacheCorrupted is returned when cache file is corrupted and cannot be read
+	ErrCacheCorrupted = errors.New("cache file is corrupted")
+
+	// ErrCachePermission is returned when there are permission issues with cache file or directory
+	ErrCachePermission = errors.New("permission denied for cache file or directory")
+
+	// ErrCacheDirectoryCreate is returned when cache directory cannot be created
+	ErrCacheDirectoryCreate = errors.New("failed to create cache directory")
+)

--- a/internal/domain/cache/file_cache.go
+++ b/internal/domain/cache/file_cache.go
@@ -1,0 +1,317 @@
+package cache
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/canpok1/ai-feed/internal/domain"
+	"github.com/canpok1/ai-feed/internal/domain/entity"
+)
+
+// FileRecommendCache implements RecommendCache interface using JSON Lines file format
+type FileRecommendCache struct {
+	filePath string
+	lockPath string
+	urlSet   map[string]bool
+	entries  []domain.RecommendEntry
+	config   *entity.CacheConfig
+	lockFile *os.File
+}
+
+// NewFileRecommendCache creates a new FileRecommendCache instance
+func NewFileRecommendCache(config *entity.CacheConfig) *FileRecommendCache {
+	lockPath := config.FilePath + ".lock"
+	return &FileRecommendCache{
+		filePath: config.FilePath,
+		lockPath: lockPath,
+		urlSet:   make(map[string]bool),
+		entries:  make([]domain.RecommendEntry, 0),
+		config:   config,
+	}
+}
+
+// Initialize initializes the cache, loads existing data and acquires necessary locks
+func (c *FileRecommendCache) Initialize() error {
+	slog.Debug("Initializing file recommend cache", "file_path", c.filePath)
+
+	if c.config.Enabled {
+		// Acquire lock first
+		if err := c.acquireLock(); err != nil {
+			return fmt.Errorf("failed to acquire lock: %w", err)
+		}
+
+		// Create directory if it doesn't exist
+		if err := c.createDirectoryIfNotExists(); err != nil {
+			c.releaseLock() // Release lock on error
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		// Load existing cache data
+		if err := c.loadFromFile(); err != nil {
+			c.releaseLock() // Release lock on error
+			return fmt.Errorf("failed to load cache data: %w", err)
+		}
+
+		// Cleanup old entries
+		c.cleanup()
+
+		slog.Debug("File recommend cache initialized successfully",
+			"entries_count", len(c.entries),
+			"unique_urls", len(c.urlSet))
+	} else {
+		slog.Debug("Cache is disabled, skipping initialization")
+	}
+
+	return nil
+}
+
+// IsCached checks if the given URL is already cached (duplicate check)
+func (c *FileRecommendCache) IsCached(url string) bool {
+	if !c.config.Enabled {
+		return false
+	}
+
+	normalizedURL := c.normalizeURL(url)
+	return c.urlSet[normalizedURL]
+}
+
+// AddEntry adds a new entry to the cache with the given URL and title
+func (c *FileRecommendCache) AddEntry(url, title string) error {
+	if !c.config.Enabled {
+		return nil
+	}
+
+	normalizedURL := c.normalizeURL(url)
+
+	// Check if already exists
+	if c.urlSet[normalizedURL] {
+		slog.Debug("URL already in cache, skipping", "url", normalizedURL)
+		return nil
+	}
+
+	// Create new entry
+	entry := domain.RecommendEntry{
+		URL:      normalizedURL,
+		Title:    title,
+		PostedAt: time.Now(),
+	}
+
+	// Add to in-memory structures
+	c.entries = append(c.entries, entry)
+	c.urlSet[normalizedURL] = true
+
+	// Cleanup if necessary (FIFO when max_entries exceeded)
+	c.cleanupByMaxEntries()
+
+	// Save to file
+	if err := c.saveToFile(); err != nil {
+		return fmt.Errorf("failed to save cache: %w", err)
+	}
+
+	slog.Debug("Added entry to cache", "url", normalizedURL, "title", title)
+	return nil
+}
+
+// Close closes the cache, releases locks and performs cleanup
+func (c *FileRecommendCache) Close() error {
+	if c.config.Enabled && c.lockFile != nil {
+		if err := c.releaseLock(); err != nil {
+			return fmt.Errorf("failed to release lock: %w", err)
+		}
+		slog.Debug("File recommend cache closed successfully")
+	}
+	return nil
+}
+
+// createDirectoryIfNotExists creates the cache directory if it doesn't exist
+func (c *FileRecommendCache) createDirectoryIfNotExists() error {
+	dir := filepath.Dir(c.filePath)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		slog.Debug("Creating cache directory", "dir", dir)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return domain.ErrCacheDirectoryCreate
+		}
+	}
+	return nil
+}
+
+// loadFromFile loads cache entries from the JSON Lines file
+func (c *FileRecommendCache) loadFromFile() error {
+	// Check if file exists
+	if _, err := os.Stat(c.filePath); os.IsNotExist(err) {
+		slog.Debug("Cache file does not exist, starting with empty cache", "file_path", c.filePath)
+		return nil
+	}
+
+	file, err := os.Open(c.filePath)
+	if err != nil {
+		if os.IsPermission(err) {
+			return domain.ErrCachePermission
+		}
+		return fmt.Errorf("failed to open cache file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	validEntries := make([]domain.RecommendEntry, 0)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var entry domain.RecommendEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			// Skip invalid lines (old format compatibility)
+			slog.Warn("Skipping invalid cache entry line", "error", err.Error())
+			continue
+		}
+
+		validEntries = append(validEntries, entry)
+		normalizedURL := c.normalizeURL(entry.URL)
+		c.urlSet[normalizedURL] = true
+	}
+
+	if err := scanner.Err(); err != nil {
+		return domain.ErrCacheCorrupted
+	}
+
+	c.entries = validEntries
+	slog.Debug("Loaded cache entries from file", "count", len(validEntries))
+	return nil
+}
+
+// saveToFile saves all cache entries to the JSON Lines file
+func (c *FileRecommendCache) saveToFile() error {
+	// Create temporary file for atomic write
+	tempPath := c.filePath + ".tmp"
+	file, err := os.Create(tempPath)
+	if err != nil {
+		if os.IsPermission(err) {
+			return domain.ErrCachePermission
+		}
+		return fmt.Errorf("failed to create temporary cache file: %w", err)
+	}
+	defer func() {
+		file.Close()
+		os.Remove(tempPath) // Clean up temp file on error
+	}()
+
+	// Write entries as JSON Lines
+	for _, entry := range c.entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			return fmt.Errorf("failed to marshal cache entry: %w", err)
+		}
+		if _, err := file.WriteString(string(data) + "\n"); err != nil {
+			return fmt.Errorf("failed to write cache entry: %w", err)
+		}
+	}
+
+	// Sync to disk
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("failed to sync cache file: %w", err)
+	}
+	file.Close()
+
+	// Atomic replace
+	if err := os.Rename(tempPath, c.filePath); err != nil {
+		return fmt.Errorf("failed to replace cache file: %w", err)
+	}
+
+	slog.Debug("Saved cache entries to file", "count", len(c.entries))
+	return nil
+}
+
+// acquireLock acquires the cache file lock
+func (c *FileRecommendCache) acquireLock() error {
+	lockFile, err := os.OpenFile(c.lockPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644)
+	if err != nil {
+		if os.IsExist(err) {
+			return fmt.Errorf("%w: lock file exists at %s. If no other ai-feed process is running, manually delete the lock file", domain.ErrCacheLocked, c.lockPath)
+		}
+		return fmt.Errorf("failed to create lock file: %w", err)
+	}
+
+	c.lockFile = lockFile
+	slog.Debug("Acquired cache lock", "lock_path", c.lockPath)
+	return nil
+}
+
+// releaseLock releases the cache file lock
+func (c *FileRecommendCache) releaseLock() error {
+	if c.lockFile != nil {
+		c.lockFile.Close()
+		if err := os.Remove(c.lockPath); err != nil && !os.IsNotExist(err) {
+			slog.Warn("Failed to remove lock file", "lock_path", c.lockPath, "error", err.Error())
+			return err
+		}
+		c.lockFile = nil
+		slog.Debug("Released cache lock", "lock_path", c.lockPath)
+	}
+	return nil
+}
+
+// cleanup removes old entries based on retention_days
+func (c *FileRecommendCache) cleanup() {
+	if c.config.RetentionDays <= 0 {
+		return
+	}
+
+	cutoffTime := time.Now().AddDate(0, 0, -c.config.RetentionDays)
+	validEntries := make([]domain.RecommendEntry, 0)
+	removedCount := 0
+
+	// Rebuild URL set with only valid entries
+	c.urlSet = make(map[string]bool)
+
+	for _, entry := range c.entries {
+		if entry.PostedAt.After(cutoffTime) {
+			validEntries = append(validEntries, entry)
+			normalizedURL := c.normalizeURL(entry.URL)
+			c.urlSet[normalizedURL] = true
+		} else {
+			removedCount++
+		}
+	}
+
+	if removedCount > 0 {
+		c.entries = validEntries
+		slog.Debug("Cleaned up old cache entries", "removed_count", removedCount, "remaining_count", len(validEntries))
+	}
+}
+
+// cleanupByMaxEntries removes old entries when max_entries is exceeded (FIFO)
+func (c *FileRecommendCache) cleanupByMaxEntries() {
+	if c.config.MaxEntries <= 0 || len(c.entries) <= c.config.MaxEntries {
+		return
+	}
+
+	// Calculate how many entries to remove
+	excessCount := len(c.entries) - c.config.MaxEntries
+
+	// Remove oldest entries (FIFO)
+	removedEntries := c.entries[:excessCount]
+	c.entries = c.entries[excessCount:]
+
+	// Rebuild URL set
+	c.urlSet = make(map[string]bool)
+	for _, entry := range c.entries {
+		normalizedURL := c.normalizeURL(entry.URL)
+		c.urlSet[normalizedURL] = true
+	}
+
+	slog.Debug("Cleaned up excess cache entries", "removed_count", len(removedEntries), "remaining_count", len(c.entries))
+}
+
+// normalizeURL normalizes URL by removing trailing slash
+func (c *FileRecommendCache) normalizeURL(url string) string {
+	return strings.TrimSuffix(url, "/")
+}

--- a/internal/domain/entity/config.go
+++ b/internal/domain/entity/config.go
@@ -314,7 +314,6 @@ type Profile struct {
 	AI     *AIConfig
 	Prompt *PromptConfig
 	Output *OutputConfig
-	Cache  *CacheConfig
 }
 
 // Validate はProfileの内容をバリデーションする
@@ -353,7 +352,6 @@ func (p *Profile) Merge(other *Profile) {
 	mergePtr(&p.AI, other.AI)
 	mergePtr(&p.Prompt, other.Prompt)
 	mergePtr(&p.Output, other.Output)
-	mergePtr(&p.Cache, other.Cache)
 }
 
 type OutputConfig struct {

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -19,7 +19,6 @@ type Profile struct {
 	AI     *AIConfig     `yaml:"ai,omitempty"`
 	Prompt *PromptConfig `yaml:",inline,omitempty"`
 	Output *OutputConfig `yaml:"output,omitempty"`
-	Cache  *CacheConfig  `yaml:"cache,omitempty"`
 }
 
 // ToEntity converts infra.Profile to entity.Profile
@@ -47,20 +46,10 @@ func (p *Profile) ToEntity() (*entity.Profile, error) {
 		}
 	}
 
-	var cacheEntity *entity.CacheConfig
-	if p.Cache != nil {
-		var err error
-		cacheEntity, err = p.Cache.ToEntity()
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return &entity.Profile{
 		AI:     aiEntity,
 		Prompt: promptEntity,
 		Output: outputEntity,
-		Cache:  cacheEntity,
 	}, nil
 }
 

--- a/internal/infra/config.go
+++ b/internal/infra/config.go
@@ -19,6 +19,7 @@ type Profile struct {
 	AI     *AIConfig     `yaml:"ai,omitempty"`
 	Prompt *PromptConfig `yaml:",inline,omitempty"`
 	Output *OutputConfig `yaml:"output,omitempty"`
+	Cache  *CacheConfig  `yaml:"cache,omitempty"`
 }
 
 // ToEntity converts infra.Profile to entity.Profile
@@ -46,10 +47,20 @@ func (p *Profile) ToEntity() (*entity.Profile, error) {
 		}
 	}
 
+	var cacheEntity *entity.CacheConfig
+	if p.Cache != nil {
+		var err error
+		cacheEntity, err = p.Cache.ToEntity()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &entity.Profile{
 		AI:     aiEntity,
 		Prompt: promptEntity,
 		Output: outputEntity,
+		Cache:  cacheEntity,
 	}, nil
 }
 

--- a/internal/infra/config_test.go
+++ b/internal/infra/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/canpok1/ai-feed/internal/domain/entity"
 	"github.com/canpok1/ai-feed/internal/testutil"
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
@@ -993,6 +994,262 @@ func TestOutputConfig_EnabledFalseWithValidationErrors(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NotNil(t, entity)
 			}
+		})
+	}
+}
+
+// キャッシュ設定テスト
+
+func TestCacheConfig_ToEntity(t *testing.T) {
+	homeDir, err := os.UserHomeDir()
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		config      CacheConfig
+		expected    *entity.CacheConfig
+		expectedErr string
+	}{
+		{
+			name: "正常な設定値での変換",
+			config: CacheConfig{
+				Enabled:       testutil.BoolPtr(true),
+				FilePath:      "/tmp/cache.jsonl",
+				MaxEntries:    1000,
+				RetentionDays: 30,
+			},
+			expected: &entity.CacheConfig{
+				Enabled:       true,
+				FilePath:      "/tmp/cache.jsonl",
+				MaxEntries:    1000,
+				RetentionDays: 30,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "デフォルト値の適用",
+			config: CacheConfig{
+				Enabled:       nil,
+				FilePath:      "",
+				MaxEntries:    0,
+				RetentionDays: 0,
+			},
+			expected: &entity.CacheConfig{
+				Enabled:       false,
+				FilePath:      filepath.Join(homeDir, ".ai-feed", "recommend_history.jsonl"),
+				MaxEntries:    1000,
+				RetentionDays: 30,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "チルダ展開テスト",
+			config: CacheConfig{
+				Enabled:       testutil.BoolPtr(true),
+				FilePath:      "~/.ai-feed/custom-cache.jsonl",
+				MaxEntries:    500,
+				RetentionDays: 15,
+			},
+			expected: &entity.CacheConfig{
+				Enabled:       true,
+				FilePath:      filepath.Join(homeDir, ".ai-feed", "custom-cache.jsonl"),
+				MaxEntries:    500,
+				RetentionDays: 15,
+			},
+			expectedErr: "",
+		},
+		{
+			name: "相対パス展開テスト",
+			config: CacheConfig{
+				Enabled:       testutil.BoolPtr(false),
+				FilePath:      "./cache/data.jsonl",
+				MaxEntries:    2000,
+				RetentionDays: 60,
+			},
+			expected: &entity.CacheConfig{
+				Enabled:       false,
+				FilePath:      filepath.Join(".", "cache", "data.jsonl"),
+				MaxEntries:    2000,
+				RetentionDays: 60,
+			},
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.config.ToEntity()
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, tt.expected.Enabled, result.Enabled)
+				// パスは絶対パスに展開されるため、期待値も絶対パスに変換して比較
+				expectedPath, _ := filepath.Abs(tt.expected.FilePath)
+				actualPath, _ := filepath.Abs(result.FilePath)
+				assert.Equal(t, expectedPath, actualPath)
+				assert.Equal(t, tt.expected.MaxEntries, result.MaxEntries)
+				assert.Equal(t, tt.expected.RetentionDays, result.RetentionDays)
+			}
+		})
+	}
+}
+
+func TestProfile_ToEntity_WithCache(t *testing.T) {
+	tests := []struct {
+		name        string
+		profile     Profile
+		expectCache bool
+		expectedErr string
+	}{
+		{
+			name: "キャッシュ設定ありの場合",
+			profile: Profile{
+				AI: &AIConfig{
+					Gemini: &GeminiConfig{
+						Type:   "gemini-test",
+						APIKey: "test-key",
+					},
+				},
+				Cache: &CacheConfig{
+					Enabled:       testutil.BoolPtr(true),
+					FilePath:      "/tmp/test-cache.jsonl",
+					MaxEntries:    500,
+					RetentionDays: 15,
+				},
+			},
+			expectCache: true,
+			expectedErr: "",
+		},
+		{
+			name: "キャッシュ設定なしの場合",
+			profile: Profile{
+				AI: &AIConfig{
+					Gemini: &GeminiConfig{
+						Type:   "gemini-test",
+						APIKey: "test-key",
+					},
+				},
+				Cache: nil,
+			},
+			expectCache: false,
+			expectedErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity, err := tt.profile.ToEntity()
+
+			if tt.expectedErr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+				assert.Nil(t, entity)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, entity)
+
+				if tt.expectCache {
+					assert.NotNil(t, entity.Cache)
+					assert.True(t, entity.Cache.Enabled)
+					assert.Equal(t, 500, entity.Cache.MaxEntries)
+					assert.Equal(t, 15, entity.Cache.RetentionDays)
+				} else {
+					assert.Nil(t, entity.Cache)
+				}
+			}
+		})
+	}
+}
+
+func TestCacheConfig_YamlMarshalUnmarshal(t *testing.T) {
+	tests := []struct {
+		name      string
+		yamlInput string
+		expected  CacheConfig
+	}{
+		{
+			name: "完全な設定",
+			yamlInput: `
+cache:
+  enabled: true
+  file_path: /tmp/cache.jsonl
+  max_entries: 1000
+  retention_days: 30
+`,
+			expected: CacheConfig{
+				Enabled:       testutil.BoolPtr(true),
+				FilePath:      "/tmp/cache.jsonl",
+				MaxEntries:    1000,
+				RetentionDays: 30,
+			},
+		},
+		{
+			name: "enabled無効",
+			yamlInput: `
+cache:
+  enabled: false
+  file_path: ~/.ai-feed/disabled-cache.jsonl
+  max_entries: 0
+  retention_days: 0
+`,
+			expected: CacheConfig{
+				Enabled:       testutil.BoolPtr(false),
+				FilePath:      "~/.ai-feed/disabled-cache.jsonl",
+				MaxEntries:    0,
+				RetentionDays: 0,
+			},
+		},
+		{
+			name: "最小設定",
+			yamlInput: `
+cache:
+  enabled: true
+`,
+			expected: CacheConfig{
+				Enabled:       testutil.BoolPtr(true),
+				FilePath:      "",
+				MaxEntries:    0,
+				RetentionDays: 0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			type TestStruct struct {
+				Cache CacheConfig `yaml:"cache"`
+			}
+
+			var actual TestStruct
+			err := yaml.Unmarshal([]byte(tt.yamlInput), &actual)
+			assert.NoError(t, err)
+
+			if tt.expected.Enabled == nil {
+				assert.Nil(t, actual.Cache.Enabled)
+			} else {
+				assert.NotNil(t, actual.Cache.Enabled)
+				assert.Equal(t, *tt.expected.Enabled, *actual.Cache.Enabled)
+			}
+			assert.Equal(t, tt.expected.FilePath, actual.Cache.FilePath)
+			assert.Equal(t, tt.expected.MaxEntries, actual.Cache.MaxEntries)
+			assert.Equal(t, tt.expected.RetentionDays, actual.Cache.RetentionDays)
+
+			// Marshal テスト
+			marshaledYaml, err := yaml.Marshal(actual)
+			assert.NoError(t, err)
+
+			var remarshaledActual TestStruct
+			err = yaml.Unmarshal(marshaledYaml, &remarshaledActual)
+			assert.NoError(t, err)
+			assert.Equal(t, actual.Cache.Enabled, remarshaledActual.Cache.Enabled)
+			assert.Equal(t, actual.Cache.FilePath, remarshaledActual.Cache.FilePath)
+			assert.Equal(t, actual.Cache.MaxEntries, remarshaledActual.Cache.MaxEntries)
+			assert.Equal(t, actual.Cache.RetentionDays, remarshaledActual.Cache.RetentionDays)
 		})
 	}
 }

--- a/internal/infra/config_test.go
+++ b/internal/infra/config_test.go
@@ -1099,72 +1099,7 @@ func TestCacheConfig_ToEntity(t *testing.T) {
 	}
 }
 
-func TestProfile_ToEntity_WithCache(t *testing.T) {
-	tests := []struct {
-		name        string
-		profile     Profile
-		expectCache bool
-		expectedErr string
-	}{
-		{
-			name: "キャッシュ設定ありの場合",
-			profile: Profile{
-				AI: &AIConfig{
-					Gemini: &GeminiConfig{
-						Type:   "gemini-test",
-						APIKey: "test-key",
-					},
-				},
-				Cache: &CacheConfig{
-					Enabled:       testutil.BoolPtr(true),
-					FilePath:      "/tmp/test-cache.jsonl",
-					MaxEntries:    500,
-					RetentionDays: 15,
-				},
-			},
-			expectCache: true,
-			expectedErr: "",
-		},
-		{
-			name: "キャッシュ設定なしの場合",
-			profile: Profile{
-				AI: &AIConfig{
-					Gemini: &GeminiConfig{
-						Type:   "gemini-test",
-						APIKey: "test-key",
-					},
-				},
-				Cache: nil,
-			},
-			expectCache: false,
-			expectedErr: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			entity, err := tt.profile.ToEntity()
-
-			if tt.expectedErr != "" {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tt.expectedErr)
-				assert.Nil(t, entity)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, entity)
-
-				if tt.expectCache {
-					assert.NotNil(t, entity.Cache)
-					assert.True(t, entity.Cache.Enabled)
-					assert.Equal(t, 500, entity.Cache.MaxEntries)
-					assert.Equal(t, 15, entity.Cache.RetentionDays)
-				} else {
-					assert.Nil(t, entity.Cache)
-				}
-			}
-		})
-	}
-}
+// TestProfile_ToEntity_WithCache は削除 - ProfileはキャッシュfieldBはなくなったため
 
 func TestCacheConfig_YamlMarshalUnmarshal(t *testing.T) {
 	tests := []struct {

--- a/internal/infra/templates/config.yml
+++ b/internal/infra/templates/config.yml
@@ -95,21 +95,21 @@ default_profile:
         [{{TITLE}}]({{URL}})
         {{FIXED_MESSAGE}}
 
-  # キャッシュ設定
-  cache:
-    # 有効/無効フラグ（省略時はfalse）
-    # trueに設定すると投稿済み記事の重複を防ぐことができます
-    enabled: false
-    
-    # キャッシュファイルのパス
-    # 省略時はホームディレクトリの ~/.ai-feed/recommend_history.jsonl が使用されます
-    # file_path: ~/.ai-feed/recommend_history.jsonl
-    
-    # 最大エントリ数（FIFOで古いものから削除）
-    # 省略時は1000件
-    # max_entries: 1000
-    
-    # 保持期間（日数）
-    # 指定日数を過ぎた記事は自動的に削除されます
-    # 省略時は30日
-    # retention_days: 30
+# キャッシュ設定
+cache:
+  # 有効/無効フラグ（省略時はfalse）
+  # trueに設定すると投稿済み記事の重複を防ぐことができます
+  enabled: false
+  
+  # キャッシュファイルのパス
+  # 省略時はホームディレクトリの ~/.ai-feed/recommend_history.jsonl が使用されます
+  # file_path: ~/.ai-feed/recommend_history.jsonl
+  
+  # 最大エントリ数（FIFOで古いものから削除）
+  # 省略時は1000件
+  # max_entries: 1000
+  
+  # 保持期間（日数）
+  # 指定日数を過ぎた記事は自動的に削除されます
+  # 省略時は30日
+  # retention_days: 30

--- a/internal/infra/templates/config.yml
+++ b/internal/infra/templates/config.yml
@@ -94,3 +94,22 @@ default_profile:
         {{COMMENT}}
         [{{TITLE}}]({{URL}})
         {{FIXED_MESSAGE}}
+
+  # キャッシュ設定
+  cache:
+    # 有効/無効フラグ（省略時はfalse）
+    # trueに設定すると投稿済み記事の重複を防ぐことができます
+    enabled: false
+    
+    # キャッシュファイルのパス
+    # 省略時はホームディレクトリの ~/.ai-feed/recommend_history.jsonl が使用されます
+    # file_path: ~/.ai-feed/recommend_history.jsonl
+    
+    # 最大エントリ数（FIFOで古いものから削除）
+    # 省略時は1000件
+    # max_entries: 1000
+    
+    # 保持期間（日数）
+    # 指定日数を過ぎた記事は自動的に削除されます
+    # 省略時は30日
+    # retention_days: 30


### PR DESCRIPTION
## Summary
recommendコマンドで投稿する記事が重複しないよう、投稿履歴をキャッシュする機能を実装しました。

### 主要機能
- **重複記事の自動検出**: 投稿済み記事URLのキャッシュによる重複防止
- **JSON Lines形式での永続化**: 高いパフォーマンスとファイル管理の効率性
- **プロセス間排他制御**: ロックファイルによる安全な並行実行制御
- **自動クリーンアップ**: 最大件数・保持期間による自動的な古いエントリの削除
- **設定可能なオプション**: enabled/disabled切り替え、ファイルパス、上限設定

### アーキテクチャ改善
- キャッシュ設定をConfig.Cacheに統一（Profile.Cacheの冗長性を解消）
- ディレクトリ自動作成によるユーザビリティ向上
- initコマンドによるキャッシュ設定のテンプレート生成

### 技術仕様
- **ファイル形式**: JSON Lines (.jsonl) - 大容量対応とパフォーマンス最適化
- **重複チェック**: O(1)の in-memory URL Set による高速処理
- **並行制御**: プロセス単位のファイルロック機構
- **URL正規化**: 末尾スラッシュ除去による一意性確保
- **アトミック書き込み**: 一時ファイル経由による安全なファイル更新

### 設定例
```yaml
cache:
  enabled: true
  file_path: ~/.ai-feed/recommend_history.jsonl  # 省略時デフォルト
  max_entries: 1000                              # 省略時デフォルト
  retention_days: 30                             # 省略時デフォルト
```

## Test plan
- [x] 基本的なキャッシュ機能の動作確認
- [x] 重複記事の検出動作確認
- [x] ディレクトリ自動作成の確認
- [x] プロセス終了時のリソース管理確認
- [x] エラーハンドリングの確認
- [x] 設定ファイルのテンプレート生成確認

fixed #142

🤖 Generated with [Claude Code](https://claude.ai/code)