### PR TITLE
不要なスクリプトを削除

### DIFF
--- a/run-in-devcontainer.sh
+++ b/run-in-devcontainer.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-cd "$(dirname "$0")"
-
-devcontainer up
-devcontainer exec -- "$@"


### PR DESCRIPTION
## 概要
git worktree ごとに devcontainer を立ち上げる想定でしたが、コンテナ内で git リポジトリがうまく使えないことが分かったため断念。
devcontainer の立ち上げ用スクリプトが不要になったので削除します。
