### PR TITLE
CIのe2eをmainブランチの更新時にも実行させる

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,9 @@ name: e2e
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 概要

.github/workflows/e2e.ymlにmainブランチへのpushイベントを追加しました。 これにより、プルリクエスト時だけでなく、mainブランチへのマージ後もe2eテストが自動実行されるようになります。

## 関連Issue
fixed #208
