### PR TITLE
lintとlint-allを統合してMakefileを簡素化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,6 @@ jobs:
     - name: Lint
       run: make lint
 
-    - name: Lint with golangci-lint
-      run: make lint-all
-
     - name: Test
       run: make test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,8 @@ make build
 # テストの実行
 make test
 
-# コードの静的解析（重要：コミット前に必ず実行）
+# golangci-lintによる包括的な静的解析（重要：コミット前に必ず実行）
 make lint
-
-# golangci-lintによる包括的な静的解析
-make lint-all
 
 # テストカバレッジレポート生成（HTML形式）
 make test-coverage

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ test-coverage-check:
 	awk -v thold=$(COVERAGE_THRESHOLD) '{if ($$1 < thold) {printf "Coverage %.2f%% is below threshold %d%%\n", $$1, thold; exit 1} else {printf "Coverage %.2f%% meets threshold %d%%\n", $$1, thold}}'
 
 lint:
-	go vet ./...
-
-lint-all:
 	golangci-lint run ./...
 
 fmt:


### PR DESCRIPTION
## Summary
`lint`と`lint-all`の冗長性を解消し、Makefileとワークフローを簡素化しました。

- `make lint`を`golangci-lint run ./...`に変更
- 冗長な`make lint-all`ターゲットを削除
- CIから重複する「Lint with golangci-lint」ステップを削除
- CLAUDE.mdのドキュメントを更新

## Changes
- **Makefile**: `lint`ターゲットを`golangci-lint run ./...`に統合、`lint-all`を削除
- **.github/workflows/build.yml**: 重複するlintステップを削除
- **CLAUDE.md**: `make lint`の説明を更新、`make lint-all`への参照を削除

## Test plan
- [x] CIビルドが成功することを確認
- [x] `make lint`が正常に動作することを確認

fixed #220