### PR TITLE
version-taggingワークフローでリリース処理を自動実行するように修正

### DIFF
--- a/.github/workflows/version-tagging.yml
+++ b/.github/workflows/version-tagging.yml
@@ -17,8 +17,11 @@ jobs:
           fetch-depth: 0
 
       - name: Create and push version tag
-        id: create-tag
         run: ./scripts/create-version-tag.sh
+
+      - name: Get created tag
+        id: create-tag
+        run: echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
 
   # タグ作成後にリリースを実行
   # GITHUB_TOKENでプッシュされたタグは他のワークフローをトリガーしないため

--- a/scripts/create-version-tag.sh
+++ b/scripts/create-version-tag.sh
@@ -56,8 +56,3 @@ else
     git push origin "$NEW_VERSION"
     echo "タグ $NEW_VERSION をプッシュしました。"
 fi
-
-# GitHub Actions用に作成したタグ名を出力
-if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
-    echo "tag=$NEW_VERSION" >> "$GITHUB_OUTPUT"
-fi


### PR DESCRIPTION
## Summary

- version-taggingワークフロー内で直接GoReleaserを実行するように変更
- GITHUB_TOKENでプッシュされたタグは他のワークフローをトリガーしないGitHubの仕様に対応
- スクリプト（create-version-tag.sh）からGitHub Actions固有の処理を分離

## Background

GitHubのセキュリティ設計により、`GITHUB_TOKEN`を使用してプッシュされたタグは無限ループ防止のため他のワークフローをトリガーしません。そのため、version-taggingで作成したタグからreleaseワークフローが自動実行されない問題がありました。

## Changes

- `.github/workflows/version-tagging.yml`: タグ作成後にreleaseジョブを追加し、作成したタグをチェックアウトしてGoReleaserを実行
- `.github/workflows/release.yml`: 変更なし（タグプッシュトリガーのみ維持）

## Test plan

- [ ] version-taggingワークフローを手動実行してタグ作成とリリースが正常に完了することを確認

fixed #236
