### PR TITLE
リリース前にテストを実行するように修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,4 @@ jobs:
         args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/version-tagging.yml
+++ b/.github/workflows/version-tagging.yml
@@ -50,3 +50,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,8 @@ before:
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
+    # リリース前にテストを実行（失敗時はリリースを中止）
+    - make test-release
 
 builds:
   - env:

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ test-coverage:
 	@go tool cover -html=coverage.filtered.out -o public/coverage/ut-it/index.html
 	@go tool cover -func=coverage.filtered.out | awk -v thold=$(COVERAGE_THRESHOLD) '/^total:/ {gsub(/%/, "", $$3); if ($$3 < thold) {printf "Coverage %.2f%% is below threshold %d%%\n", $$3, thold; exit 1} else {printf "Coverage %.2f%% meets threshold %d%%\n", $$3, thold}}'
 
+# リリース前に実行するテスト（GoReleaserから呼び出される）
+test-release: test-coverage test-e2e
+
 lint:
 	golangci-lint run ./...
 


### PR DESCRIPTION
## 概要
GoReleaserのリリース前にテストが実行されていない問題を修正しました。

## 変更内容
- `.goreleaser.yaml` の `before.hooks` にテストコマンドを追加
  - `make test-coverage`: カバレッジ付きユニットテスト（60%閾値チェック）
  - `make test-e2e`: E2Eテスト
- `version-tagging.yml` と `release.yml` に `GEMINI_API_KEY` 環境変数を追加（e2eテスト実行用）

## 効果
- テスト失敗時にリリースが自動的に中止される
- カバレッジ閾値を満たさない場合もリリースが中止される

fixed #240
