### PR TITLE
docs/02_architecture.md のディレクトリ構成を抽象化してメンテナンス性を向上

### DIFF
--- a/docs/02_architecture.md
+++ b/docs/02_architecture.md
@@ -17,7 +17,7 @@ ai-feed/
 │   │   │   └── *.go           # (config, entity, secret など)
 │   │   ├── cache/              # キャッシュ実装
 │   │   │   └── *.go           # (file_cache, nop_cache など)
-│   │   ├── mock_domain/        # ドメイン層のモック（テスト用）
+│   │   ├── mock_domain/        # ドメイン層のモック（テスト用、層の純粋性維持のため分離）
 │   │   │   └── *.go           # 自動生成されるモック
 │   │   └── *.go                # インターフェース定義 (comment, fetch, message など)
 │   ├── infra/                  # インフラストラクチャ層
@@ -33,7 +33,7 @@ ai-feed/
 │   │   │   └── *.go           # (factory, gemini など)
 │   │   ├── templates/          # 設定ファイルテンプレート
 │   │   │   └── *.yml          # (config など)
-│   │   ├── mock_infra/         # インフラ層のモック（テスト用）
+│   │   ├── mock_infra/         # インフラ層のモック（テスト用、層の純粋性維持のため分離）
 │   │   │   └── *.go           # 自動生成されるモック
 │   │   └── *.go                # (config, logger, templates など)
 │   ├── testutil/               # テストユーティリティ


### PR DESCRIPTION
## 概要
ディレクトリ構成のドキュメントを抽象化し、メンテナンス性を向上させました。

## 変更内容
- 個別ファイル名の列挙を `*.go` 形式のワイルドカード表記に変更
- 代表的なファイル名を括弧内に例示（例: `(profile_check, profile_init, recommend など)`）
- 実際のコードベースに合わせて欠落していたディレクトリを追加
  - `internal/domain/cache/`
  - `internal/infra/selector/`
  - `internal/testutil/`
  - `internal/version/`
  - `test/e2e/`

## メリット
- 新規ファイル追加時にドキュメント更新が不要
- ドキュメントと実コードの乖離が発生しにくい
- ディレクトリの役割説明は維持されるため、アーキテクチャの理解には影響なし

## テスト
ドキュメントのみの変更のため、動作確認不要

fixed #264
