### PR TITLE
viewer を sender にリネームして役割を明確化

### DIFF
--- a/internal/infra/message/misskey_test.go
+++ b/internal/infra/message/misskey_test.go
@@ -41,18 +41,18 @@ func TestNewMisskeySender(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			viewer, err := NewMisskeySender(tt.instanceURL, tt.accessToken, tt.messageTemplate)
+			sender, err := NewMisskeySender(tt.instanceURL, tt.accessToken, tt.messageTemplate)
 
 			if tt.expectError {
 				assert.Error(t, err)
-				assert.Nil(t, viewer)
+				assert.Nil(t, sender)
 				return
 			}
 
 			require.NoError(t, err)
-			require.NotNil(t, viewer)
+			require.NotNil(t, sender)
 
-			misskeySender, ok := viewer.(*MisskeySender)
+			misskeySender, ok := sender.(*MisskeySender)
 			require.True(t, ok, "Should be MisskeySender type")
 
 			// テンプレートが正しくパースされていることを確認


### PR DESCRIPTION
## 概要

`domain.MessageSender` インターフェースを実装するオブジェクトの変数名・フィールド名を「viewer」（受動的な役割）から「sender」（能動的な役割）に変更し、実際の役割（メッセージを送信する）に合わせた命名に統一しました。

### 変更内容

**cmd/runner/recommend.go:**
- 構造体フィールド: `viewers` → `senders`
- 変数名: `viewer` → `sender`, `slackViewer` → `slackSender`, `misskeyViewer` → `misskeySender`
- エラー変数: `viewErr` → `sendErr`
- ログメッセージ: `viewer_count` → `sender_count`
- エラーメッセージ: `failed to view recommend` → `failed to send recommend`
- エラーメッセージ: `failed to create Misskey viewer` → `failed to create Misskey sender`
- ログメッセージ: `Recommendation sent successfully to all viewers` → `Recommendation sent successfully to all senders`

**cmd/runner/recommend_test.go:**
- テストケース名: `Viewer無し` → `Sender無し`, `SlackAPI Viewer` → `SlackAPI Sender` 等
- 変数名: `expectedViewers` → `expectedSenders`, `runner.viewers` → `runner.senders`
- コメント: `viewersスライス` → `sendersスライス`

**internal/infra/message/misskey_test.go:**
- 変数名: `viewer` → `sender`

### 確認事項
- [x] 純粋なリファクタリングでロジック変更なし
- [x] 関連するすべてのテストがパス

## 関連Issue

fixed #270
