### PR TITLE
テストヘルパー関数の重複を解消しtestutilパッケージに統合

### DIFF
--- a/cmd/runner/recommend_test.go
+++ b/cmd/runner/recommend_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canpok1/ai-feed/internal/domain"
 	"github.com/canpok1/ai-feed/internal/domain/entity"
 	"github.com/canpok1/ai-feed/internal/domain/mock_domain"
+	"github.com/canpok1/ai-feed/internal/testutil"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,10 +32,6 @@ func createMockConfig(promptConfig *entity.PromptConfig, outputConfig *entity.Ou
 		Prompt: promptConfig,
 		Output: outputConfig,
 	}
-}
-
-func toStringP(value string) *string {
-	return &value
 }
 
 func TestNewRecommendRunner(t *testing.T) {
@@ -58,7 +55,7 @@ func TestNewRecommendRunner(t *testing.T) {
 					Enabled:         true,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			promptConfig: &entity.PromptConfig{CommentPromptTemplate: "test-template"},
@@ -71,7 +68,7 @@ func TestNewRecommendRunner(t *testing.T) {
 					Enabled:         true,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io/api",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			promptConfig: &entity.PromptConfig{CommentPromptTemplate: "test-template"},
@@ -172,7 +169,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 			params: &RecommendParams{
 				URLs: []string{"http://example.com/empty.xml"},
 			},
-			expectedErrorMessage: toStringP("no articles found in the feed"),
+			expectedErrorMessage: testutil.StringPtr("no articles found in the feed"),
 		},
 		{
 			name: "異常系: フェッチエラー",
@@ -185,7 +182,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 			params: &RecommendParams{
 				URLs: []string{"http://invalid.com/feed.xml"},
 			},
-			expectedErrorMessage: toStringP("no articles found in the feed"),
+			expectedErrorMessage: testutil.StringPtr("no articles found in the feed"),
 		},
 		{
 			name: "異常系: 推薦エラー",
@@ -200,7 +197,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 			params: &RecommendParams{
 				URLs: []string{"http://example.com/feed.xml"},
 			},
-			expectedErrorMessage: toStringP("failed to recommend article: mock recommend error"),
+			expectedErrorMessage: testutil.StringPtr("failed to recommend article: mock recommend error"),
 		},
 		{
 			name: "正常系: AIモデル未設定",
@@ -382,13 +379,13 @@ func TestNewRecommendRunner_EnabledFlags(t *testing.T) {
 					Enabled:         true,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 				Misskey: &entity.MisskeyConfig{
 					Enabled:         true,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedSenders: 2,
@@ -400,13 +397,13 @@ func TestNewRecommendRunner_EnabledFlags(t *testing.T) {
 					Enabled:         true,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 				Misskey: &entity.MisskeyConfig{
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedSenders: 1,
@@ -418,13 +415,13 @@ func TestNewRecommendRunner_EnabledFlags(t *testing.T) {
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 				Misskey: &entity.MisskeyConfig{
 					Enabled:         true,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedSenders: 1,
@@ -436,13 +433,13 @@ func TestNewRecommendRunner_EnabledFlags(t *testing.T) {
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 				Misskey: &entity.MisskeyConfig{
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedSenders: 0,
@@ -490,7 +487,7 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedLogs: []string{"Slack API output is disabled (enabled: false)"},
@@ -502,7 +499,7 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedLogs: []string{"Misskey output is disabled (enabled: false)"},
@@ -514,13 +511,13 @@ func TestRecommendRunner_Run_EnabledFlagsLogging(t *testing.T) {
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					Channel:         "#test",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 				Misskey: &entity.MisskeyConfig{
 					Enabled:         false,
 					APIToken:        makeSecretString("test-token"),
 					APIURL:          "https://test.misskey.io",
-					MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+					MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 				},
 			},
 			expectedLogs: []string{
@@ -587,13 +584,13 @@ func TestRecommendRunner_Run_AllOutputsDisabled(t *testing.T) {
 			Enabled:         false,
 			APIToken:        makeSecretString("test-token"),
 			Channel:         "#test",
-			MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+			MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 		},
 		Misskey: &entity.MisskeyConfig{
 			Enabled:         false,
 			APIToken:        makeSecretString("test-token"),
 			APIURL:          "https://test.misskey.io",
-			MessageTemplate: stringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
+			MessageTemplate: testutil.StringPtr("{{.Article.Title}}\n{{.Article.Link}}"),
 		},
 	}
 
@@ -655,7 +652,7 @@ func TestRecommendRunner_Run_ConfigLogging(t *testing.T) {
 	stdoutBuffer := new(bytes.Buffer)
 
 	// テスト用の設定値を作成
-	testOutputConfig := &entity.OutputConfig{SlackAPI: &entity.SlackAPIConfig{Enabled: true, APIToken: makeSecretString("slack-token"), Channel: "#general", MessageTemplate: toStringP("test-template")}}
+	testOutputConfig := &entity.OutputConfig{SlackAPI: &entity.SlackAPIConfig{Enabled: true, APIToken: makeSecretString("slack-token"), Channel: "#general", MessageTemplate: testutil.StringPtr("test-template")}}
 	testPromptConfig := &entity.PromptConfig{CommentPromptTemplate: "test-prompt", FixedMessage: "test-fixed-message"}
 	testCacheConfig := &entity.CacheConfig{Enabled: false, FilePath: "/tmp/test-cache"}
 	testProfile := &entity.Profile{

--- a/cmd/runner/test_helpers.go
+++ b/cmd/runner/test_helpers.go
@@ -1,6 +1,0 @@
-package runner
-
-// stringPtr はテスト用にstring値のポインタを返すヘルパー関数
-func stringPtr(s string) *string {
-	return &s
-}

--- a/internal/infra/message/testutil_test.go
+++ b/internal/infra/message/testutil_test.go
@@ -1,6 +1,0 @@
-package message
-
-// stringPtr はテスト用のヘルパー関数：文字列のポインタを返す
-func stringPtr(s string) *string {
-	return &s
-}

--- a/internal/testutil/helpers.go
+++ b/internal/testutil/helpers.go
@@ -1,11 +1,11 @@
 package testutil
 
-// BoolPtr returns a pointer to the given bool value
+// BoolPtr はbool値へのポインタを返すテスト用ヘルパー関数
 func BoolPtr(b bool) *bool {
 	return &b
 }
 
-// StringPtr returns a pointer to the given string value
+// StringPtr は文字列値へのポインタを返すテスト用ヘルパー関数
 func StringPtr(s string) *string {
 	return &s
 }

--- a/test/integration/config/secret_test.go
+++ b/test/integration/config/secret_test.go
@@ -8,14 +8,10 @@ import (
 	"testing"
 
 	"github.com/canpok1/ai-feed/internal/infra"
+	"github.com/canpok1/ai-feed/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// boolPtr はbool値へのポインタを返すヘルパー関数
-func boolPtr(b bool) *bool {
-	return &b
-}
 
 // ============================================================================
 // Gemini APIキー解決テスト
@@ -35,7 +31,7 @@ func TestGeminiSecret_SecretResolution(t *testing.T) {
 		{
 			name:         "直接指定優先: api_keyとapi_key_env両方指定時、api_keyが優先される",
 			envVarName:   "TEST_GEMINI_API_KEY_SECRET",
-			envVarValue:  stringPtr("api-key-from-env"),
+			envVarValue:  testutil.StringPtr("api-key-from-env"),
 			directAPIKey: "direct-api-key",
 			wantErr:      false,
 			wantAPIKey:   "direct-api-key",
@@ -51,7 +47,7 @@ func TestGeminiSecret_SecretResolution(t *testing.T) {
 		{
 			name:           "環境変数空文字: 環境変数が空文字の場合エラー",
 			envVarName:     "TEST_GEMINI_API_KEY_EMPTY",
-			envVarValue:    stringPtr(""),
+			envVarValue:    testutil.StringPtr(""),
 			directAPIKey:   "",
 			wantErr:        true,
 			wantErrContain: "TEST_GEMINI_API_KEY_EMPTY",
@@ -113,7 +109,7 @@ func TestSlackSecret_SecretResolution(t *testing.T) {
 		{
 			name:        "直接指定優先: api_tokenとapi_token_env両方指定時、api_tokenが優先される",
 			envVarName:  "TEST_SLACK_API_TOKEN_SECRET",
-			envVarValue: stringPtr("token-from-env"),
+			envVarValue: testutil.StringPtr("token-from-env"),
 			directToken: "direct-token",
 			wantErr:     false,
 			wantToken:   "direct-token",
@@ -129,7 +125,7 @@ func TestSlackSecret_SecretResolution(t *testing.T) {
 		{
 			name:           "環境変数空文字: 環境変数が空文字の場合エラー",
 			envVarName:     "TEST_SLACK_API_TOKEN_EMPTY",
-			envVarValue:    stringPtr(""),
+			envVarValue:    testutil.StringPtr(""),
 			directToken:    "",
 			wantErr:        true,
 			wantErrContain: "TEST_SLACK_API_TOKEN_EMPTY",
@@ -152,7 +148,7 @@ func TestSlackSecret_SecretResolution(t *testing.T) {
 				Prompt: NewPromptConfig(),
 				Output: &infra.OutputConfig{
 					SlackAPI: &infra.SlackAPIConfig{
-						Enabled:     boolPtr(true),
+						Enabled:     testutil.BoolPtr(true),
 						APIToken:    tt.directToken,
 						APITokenEnv: tt.envVarName,
 						Channel:     "#test-channel",
@@ -192,7 +188,7 @@ func TestMisskeySecret_SecretResolution(t *testing.T) {
 		{
 			name:        "直接指定優先: api_tokenとapi_token_env両方指定時、api_tokenが優先される",
 			envVarName:  "TEST_MISSKEY_API_TOKEN_SECRET",
-			envVarValue: stringPtr("token-from-env"),
+			envVarValue: testutil.StringPtr("token-from-env"),
 			directToken: "direct-token",
 			wantErr:     false,
 			wantToken:   "direct-token",
@@ -208,7 +204,7 @@ func TestMisskeySecret_SecretResolution(t *testing.T) {
 		{
 			name:           "環境変数空文字: 環境変数が空文字の場合エラー",
 			envVarName:     "TEST_MISSKEY_API_TOKEN_EMPTY",
-			envVarValue:    stringPtr(""),
+			envVarValue:    testutil.StringPtr(""),
 			directToken:    "",
 			wantErr:        true,
 			wantErrContain: "TEST_MISSKEY_API_TOKEN_EMPTY",
@@ -231,7 +227,7 @@ func TestMisskeySecret_SecretResolution(t *testing.T) {
 				Prompt: NewPromptConfig(),
 				Output: &infra.OutputConfig{
 					Misskey: &infra.MisskeyConfig{
-						Enabled:     boolPtr(true),
+						Enabled:     testutil.BoolPtr(true),
 						APIToken:    tt.directToken,
 						APITokenEnv: tt.envVarName,
 						APIURL:      "http://localhost:3000",
@@ -251,9 +247,4 @@ func TestMisskeySecret_SecretResolution(t *testing.T) {
 			}
 		})
 	}
-}
-
-// stringPtr はstring値へのポインタを返すヘルパー関数
-func stringPtr(s string) *string {
-	return &s
 }


### PR DESCRIPTION
## 概要
テストヘルパー関数（stringPtr, boolPtr, toStringP）が複数のファイルに重複定義されていた問題を解消し、testutilパッケージに統合しました。これにより、コードの保守性が向上し、DRY原則に準拠した実装となりました。

### 変更内容
- **削除したファイル**:
  - `internal/infra/message/testutil_test.go`: 未使用のstringPtr関数のみが定義されていたため削除
  - `cmd/runner/test_helpers.go`: stringPtr関数のみが定義されていたため削除

- **修正したファイル**:
  - `test/integration/config/secret_test.go`:
    - ローカル定義のstringPtr/boolPtr関数を削除
    - testutilパッケージをimportし、testutil.StringPtr(), testutil.BoolPtr()に置き換え
  
  - `cmd/runner/recommend_test.go`:
    - ローカル定義のtoStringP関数を削除
    - testutilパッケージをimportし、testutil.StringPtr()に置き換え
  
  - `internal/testutil/helpers.go`:
    - コメントを英語から日本語に修正（コーディング規約準拠）

### テスト結果
- すべてのテストが正常にパス
- 既存機能への影響なし

## 関連Issue
fixed #311
