### PR TITLE
CIの効率化: make testの重複実行を解消

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,6 @@ jobs:
     - name: Depcheck
       run: make depcheck
 
-    - name: Test
-      run: make test
-
     - name: Test Coverage Check
       run: make test-coverage
 


### PR DESCRIPTION
## 概要
CIワークフロー（.github/workflows/build.yml）でテストが重複実行されている問題を解消しました。`make test`ステップを削除し、`make test-coverage`のみを実行することで、CI実行時間を短縮しリソースを最適化します。`make test-coverage`は`make test`の範囲を包含しており、さらに統合テストとカバレッジレポートも含まれています。

## 関連Issue
fixed #341
