### PR TITLE
docs: app層のテスト戦略ドキュメントを実態に合わせて更新

### DIFF
--- a/docs/03_testing_rules.md
+++ b/docs/03_testing_rules.md
@@ -104,6 +104,7 @@ func TestRecommendRunner_Run(t *testing.T) {
 //go:build integration
 
 // test/integration/app/profile_init_integration_test.go
+// ※簡潔さのため、テストの実行ループやリポジトリのセットアップ等は省略しています
 func TestProfileInitRunner_Run_WithRealRepository(t *testing.T) {
     tests := []struct {
         name    string


### PR DESCRIPTION
## 概要
app層のテスト戦略ドキュメントが実際のコードベースと乖離していたため、実態に合わせて更新しました。

### 変更点
- テスト戦略概要表でapp層を「統合テスト」から「ユニット + 統合テスト」に更新
- テスト種類の使い分け表を追加（用途と配置場所を明確化）
- ユニットテストと統合テストの具体的なコード例を追加
- 各テスト種類の対象を明確に分離して記載

### 背景
実際のコードベースでは:
- `internal/app/*_test.go`: モックを使ったユニットテスト（複雑な条件分岐、エラーハンドリング等）
- `test/integration/app/*_test.go`: 実際のファイルシステムを使った統合テスト

というハイブリッドアプローチを採用していますが、ドキュメントには「統合テストのみ」と記載されていました。

## 関連Issue
Closes #349
